### PR TITLE
initialize internal state at Agent initialization

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -144,6 +144,7 @@ class Agent(object):
 
         self.episode = 0
         self.timestep = 0
+        self.next_internal = self.current_internal = self.model.reset()
 
     def __str__(self):
         return str(self.__class__.name)


### PR DESCRIPTION
I ran into the following error with the example shown in the [blog post](https://reinforce.io/blog/introduction-to-tensorforce/) with DQNAgent.

```
  File "/Users/nagachika/work/tensorforce/tensorforce/agents/agent.py", line 178, in act
    self.current_internal = self.next_internal
AttributeError: 'DQNAgent' object has no attribute 'next_internal'
```
