### PR TITLE
Add ALE environment

### DIFF
--- a/examples/ale.py
+++ b/examples/ale.py
@@ -1,0 +1,128 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Arcade Learning Environment execution
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import argparse
+import logging
+import os
+import sys
+
+from tensorforce import Configuration, TensorForceError
+from tensorforce.core.networks import from_json
+from tensorforce.agents import agents
+from tensorforce.environments.ale import ALE
+from tensorforce.execution import Runner
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('rom', help="File path of the rom")
+    parser.add_argument('-a', '--agent', help='Agent')
+    parser.add_argument('-c', '--agent-config', help="Agent configuration file")
+    parser.add_argument('-n', '--network-config', help="Network configuration file")
+    parser.add_argument('-fs', '--frame-skip', help="Number of frames to repeat action", type=int, default=1)
+    parser.add_argument('-rc', '--reward-clipping', help="Reward clipping. EX: -1 1", nargs="+", type=float)
+    parser.add_argument('-rap', '--repeat-action-probability', help="Repeat action probability", type=float, default=0.0)
+    parser.add_argument('-lolt', '--loss-of-life-termination', help="Loss of life counts as terminal state", action='store_true')
+    parser.add_argument('-lolr', '--loss-of-life-reward', help="Loss of life reward/penalty. EX: -1 to penalize", type=float, default=0.0)
+    parser.add_argument('-ds', '--display-screen', action='store_true', default=False, help="Display emulator screen")
+    parser.add_argument('-e', '--episodes', type=int, default=50000, help="Number of episodes")
+    parser.add_argument('-t', '--max-timesteps', type=int, default=2000, help="Maximum number of timesteps per episode")
+    parser.add_argument('-s', '--save', help="Save agent to this dir")
+    parser.add_argument('-se', '--save-episodes', type=int, default=100, help="Save agent every x episodes")
+    parser.add_argument('-l', '--load', help="Load agent from this dir")
+    parser.add_argument('-D', '--debug', action='store_true', default=False, help="Show debug outputs")
+
+    args = parser.parse_args()
+
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)  # configurable!!!
+    logger.addHandler(logging.StreamHandler(sys.stdout))
+
+    environment = ALE(args.rom, frame_skip=args.frame_skip, reward_clipping=args.reward_clipping,
+                      repeat_action_probability=args.repeat_action_probability,
+                      loss_of_life_termination=args.loss_of_life_termination,
+                      loss_of_life_reward=args.loss_of_life_reward,
+                      display_screen=args.display_screen)
+
+    if args.agent_config:
+        agent_config = Configuration.from_json(args.agent_config)
+    else:
+        agent_config = Configuration()
+        logger.info("No agent configuration provided.")
+    if args.network_config:
+        network = from_json(args.network_config)
+    else:
+        network = None
+        logger.info("No network configuration provided.")
+    agent_config.default(dict(states=environment.states, actions=environment.actions, network=network))
+    agent = agents[args.agent](config=agent_config)
+
+    if args.load:
+        load_dir = os.path.dirname(args.load)
+        if not os.path.isdir(load_dir):
+            raise OSError("Could not load agent from {}: No such directory.".format(load_dir))
+        agent.load_model(args.load)
+
+    if args.debug:
+        logger.info("-" * 16)
+        logger.info("Configuration:")
+        logger.info(agent_config)
+
+    if args.save:
+        save_dir = os.path.dirname(args.save)
+        if not os.path.isdir(save_dir):
+            try:
+                os.mkdir(save_dir, 0o755)
+            except OSError:
+                raise OSError("Cannot save agent to dir {} ()".format(save_dir))
+
+    runner = Runner(
+        agent=agent,
+        environment=environment,
+        repeat_actions=1,
+        save_path=args.save,
+        save_episodes=args.save_episodes
+    )
+
+    report_episodes = args.episodes // 1000
+    if args.debug:
+        report_episodes = 1
+
+    def episode_finished(r):
+        if r.episode % report_episodes == 0:
+            logger.info("Finished episode {ep} after {ts} timesteps".format(ep=r.episode, ts=r.timestep))
+            logger.info("Episode reward: {}".format(r.episode_rewards[-1]))
+            logger.info("Average of last 500 rewards: {}".format(sum(r.episode_rewards[-500:]) / 500))
+            logger.info("Average of last 100 rewards: {}".format(sum(r.episode_rewards[-100:]) / 100))
+        return True
+
+    logger.info("Starting {agent} for Environment '{env}'".format(agent=agent, env=environment))
+    runner.run(args.episodes, args.max_timesteps, episode_finished=episode_finished)
+    logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.episode))
+
+    environment.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tensorforce/environments/ale.py
+++ b/tensorforce/environments/ale.py
@@ -1,0 +1,132 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Arcade Learning Environment (ALE). https://github.com/mgbellemare/Arcade-Learning-Environment
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import numpy as np
+from ale_python_interface import ALEInterface
+
+from tensorforce import TensorForceError
+from tensorforce.environments import Environment
+
+
+class ALE(Environment):
+
+    def __init__(self, rom, frame_skip=1, reward_clipping=None, repeat_action_probability=0.0,
+                 loss_of_life_termination=False, loss_of_life_reward=0, display_screen=False,
+                 seed=np.random.RandomState()):
+        """
+        Initialize ALE.
+
+        Args:
+            rom: Rom filename and directory.
+            frame_skip: Repeat action for n frames. Default 1.
+            reward_clipping: Clip rewards between (low, high). Can be None. Default None.
+            repeat_action_probability: Repeats last action with given probability. Default 0.
+            loss_of_life_termination: Signals a terminal state on loss of life. Default False.
+            loss_of_life_reward: Reward/Penalty on loss of life (negative values are a penalty). Default 0.
+            display_screen: Displays the emulator screen. Default False.
+            seed: Random seed
+        """
+
+        self.ale = ALEInterface()
+        self.rom = rom
+
+        self.ale.setBool(b'display_screen', display_screen)
+        self.ale.setInt(b'random_seed', seed.randint(0, 9999))
+        self.ale.setFloat(b'repeat_action_probability', repeat_action_probability)
+        self.ale.setBool(b'color_averaging', False)
+        self.ale.setInt(b'frame_skip', frame_skip)
+
+        # all set commands must be done before loading the ROM
+        self.ale.loadROM(rom.encode())
+
+        # setup gamescreen object
+        width, height = self.ale.getScreenDims()
+        self.gamescreen = np.empty((height, width, 3), dtype=np.uint8)
+
+        self.frame_skip = frame_skip
+
+        # setup action converter
+        # ALE returns legal action indexes, convert these to just numbers
+        self.action_inds = self.ale.getMinimalActionSet()
+
+        # setup lives
+        self.loss_of_life_reward = loss_of_life_reward
+        self.cur_lives = self.ale.lives()
+        self.loss_of_life_termination = loss_of_life_termination
+        self.life_lost = False
+
+        # reward clipping
+        self.reward_clipping = reward_clipping
+
+    def __str__(self):
+        return 'ALE({})'.format(self.rom)
+
+    def close(self):
+        self.ale = None
+
+    def reset(self):
+        self.ale.reset_game()
+        self.cur_lives = self.ale.lives()
+        self.life_lost = False
+        # clear gamescreen
+        self.gamescreen = np.empty(self.gamescreen.shape, dtype=np.uint8)
+        return self.current_state
+
+    def execute(self, action):
+        # convert action to ale action
+        ale_action = self.action_inds[action]
+
+        # get reward and process terminal & next state
+        rew = self.ale.act(ale_action)
+        if self.loss_of_life_termination or self.loss_of_life_reward != 0:
+            new_lives = self.ale.lives()
+            if new_lives < self.cur_lives:
+                self.cur_lives = new_lives
+                self.life_lost = True
+                rew += self.loss_of_life_reward
+
+        if self.reward_clipping is not None:
+            rew = np.clip(rew, self.reward_clipping[0], self.reward_clipping[1])
+        terminal = self.is_terminal
+        state_tp1 = self.current_state
+        return state_tp1, rew, terminal
+
+    @property
+    def states(self):
+        return dict(shape=self.gamescreen.shape, type=float)
+
+    @property
+    def actions(self):
+        return dict(continuous=False, num_actions=len(self.action_inds))
+
+    @property
+    def current_state(self):
+        self.gamescreen = self.ale.getScreenRGB(self.gamescreen)
+        return self.gamescreen
+
+    @property
+    def is_terminal(self):
+        if self.loss_of_life_termination and self.life_lost:
+            return True
+        else:
+            return self.ale.game_over()


### PR DESCRIPTION
Adds the Arcade learning environment from https://github.com/mgbellemare/Arcade-Learning-Environment.

I'm not sure where to put reward clipping (if it should be handled by the agent or the environment) so I just put it here.
Additionally the loss of life termination that was used in the Nature DQN is available as a parameter or a negative reward can be set for losing a life.
While frame_skip is the same as runner repeat actions, it's handled by the underlying code of the ALE and is faster than looping in python. 