### PR TITLE
Weights kwargs for linear layer

### DIFF
--- a/tensorforce/core/distributions/gaussian.py
+++ b/tensorforce/core/distributions/gaussian.py
@@ -51,7 +51,7 @@ class Gaussian(Distribution):
             bias = [self.mean for _ in range(flat_size)]
         else:
             bias = self.mean
-        self.mean = layers['linear'](x=x, size=flat_size, bias=bias)
+        self.mean = layers['linear'](x=x, size=flat_size, bias=bias, weights=0.)
         self.mean = tf.reshape(tensor=self.mean, shape=((-1,) + self.shape))
         # self.mean = tf.squeeze(input=self.mean, axis=1)
         if isinstance(self.log_stddev, float):

--- a/tensorforce/core/networks/layers.py
+++ b/tensorforce/core/networks/layers.py
@@ -66,15 +66,13 @@ def linear(x, size, bias=True, l2_regularization=0.0):
     if util.rank(x) != 2:
         raise TensorForceError('Invalid input rank for linear layer.')
     with tf.variable_scope('linear'):
+        shape = (x.shape[1].value, size)
+        stddev = min(0.1, sqrt(2.0 / (x.shape[1].value + size)))
+        weights = tf.random_normal(shape=shape, stddev=stddev)
         if isinstance(bias, bool):
-            shape = (x.shape[1].value, size)
-            stddev = min(0.1, sqrt(2.0 / (x.shape[1].value + size)))
-            weights = tf.random_normal(shape=shape, stddev=stddev)
             bias = tf.zeros(shape=(size,)) if bias else None
-        else:
-            weights = tf.zeros(shape=(x.shape[1].value, size))
-            if len(bias) != size:
-                raise TensorForceError('Given bias has the wrong size.')
+        elif len(bias) != size:
+            raise TensorForceError('Given bias has the wrong size.')
         weights = tf.Variable(initial_value=weights)
         if l2_regularization > 0.0:
             tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=weights))


### PR DESCRIPTION
Initializing weights to zero if a bias is provided seems like a dangerous default if someone decides to explicitly specify a zero bias for some reason. I think this is mostly used by the `Gaussian` distribution to create a zero-mean policy. This PR adds an additional `weights` keyword argument to `linear', which seems cleaner.