### PR TITLE
Add divide by constant preprocessing

### DIFF
--- a/tensorforce/core/preprocessing/__init__.py
+++ b/tensorforce/core/preprocessing/__init__.py
@@ -19,6 +19,7 @@ from tensorforce.core.preprocessing.normalize import Normalize
 from tensorforce.core.preprocessing.center import Center
 from tensorforce.core.preprocessing.grayscale import Grayscale
 from tensorforce.core.preprocessing.image_resize import ImageResize
+from tensorforce.core.preprocessing.divide import Divide
 from tensorforce.core.preprocessing.preprocessing import Preprocessing
 
 
@@ -27,8 +28,9 @@ preprocessors = dict(
     normalize=Normalize,
     center=Center,
     grayscale=Grayscale,
-    image_resize=ImageResize
+    image_resize=ImageResize,
+    divide=Divide,
 )
 
 
-__all__ = ['Preprocessor', 'Sequence', 'Normalize', 'Center', 'Grayscale', 'ImageResize', 'Preprocessing', 'preprocessors']
+__all__ = ['Preprocessor', 'Sequence', 'Normalize', 'Center', 'Grayscale', 'ImageResize', 'Preprocessing', 'Divide', 'preprocessors']

--- a/tensorforce/core/preprocessing/divide.py
+++ b/tensorforce/core/preprocessing/divide.py
@@ -1,0 +1,36 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Divide data by a constant scalar.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorforce.core.preprocessing import Preprocessor
+
+
+class Divide(Preprocessor):
+    """
+    Divide state by scale.
+    """
+    def __init__(self, scale):
+        super(Divide, self).__init__()
+        self.scale = scale
+
+    def process(self, state):
+        return state / self.scale


### PR DESCRIPTION
Preprocessing to divide by a constant. Useful if images are returned as uint8 and need to be normalized into the 0-1 range