### PR TITLE
Fix Q model training variables error

### DIFF
--- a/examples/configs/dqn_agent.json
+++ b/examples/configs/dqn_agent.json
@@ -29,5 +29,5 @@
 
   "update_target_weight": 1.0,
   "double_dqn": false,
-  "clip_gradients": 0.0
+  "clip_loss": 0.0
 }

--- a/examples/configs/dqn_agent_visual.json
+++ b/examples/configs/dqn_agent_visual.json
@@ -45,5 +45,5 @@
 
   "update_target_weight": 1.0,
   "double_dqn": false,
-  "clip_gradients": 0.0
+  "clip_loss": 0.0
 }

--- a/tensorforce/agents/dqfd_agent.py
+++ b/tensorforce/agents/dqfd_agent.py
@@ -15,7 +15,7 @@
 
 """
 Deep Q-learning from demonstration. This agent pre-trains from demonstration data.
- 
+
 Original paper: 'Learning from Demonstrations for Real World Reinforcement Learning'
 
 https://arxiv.org/abs/1704.03732
@@ -72,7 +72,7 @@ class DQFDAgent(MemoryAgent):
     * `demo_sampling_ratio`: float, ratio of expert data used at runtime to train from.
     * `supervised_weight`: float, weight of large margin classifier loss.
     * `expert_margin`: float of difference in Q-values between expert action and other actions enforced by the large margin function.
-    * `clip_gradients`: float of maximum values for gradients before clipping.
+    * `clip_loss`: float if not 0, uses the huber loss with clip_loss as the linear bound
 
 
     """
@@ -104,10 +104,10 @@ class DQFDAgent(MemoryAgent):
         """Adds observations, updates via sampling from memories according to update rate.
         DQFD samples from the online replay memory and the demo memory with
         the fractions controlled by a hyper parameter p called 'expert sampling ratio.
-        
+
         Args:
-            reward: 
-            terminal: 
+            reward:
+            terminal:
 
         Returns:
 
@@ -126,7 +126,7 @@ class DQFDAgent(MemoryAgent):
         """Imports demonstrations, i.e. expert observations
 
         Args:
-            demonstrations: 
+            demonstrations:
 
         Returns:
 
@@ -150,7 +150,7 @@ class DQFDAgent(MemoryAgent):
 
     def pretrain(self, steps):
         """Computes pretrain updates.
-        
+
         Args:
             steps: Number of updates to execute.
 

--- a/tensorforce/agents/dqn_agent.py
+++ b/tensorforce/agents/dqn_agent.py
@@ -70,7 +70,7 @@ class DQNAgent(MemoryAgent):
     * `target_update_frequency`: int of states between updates of the target network.
     * `update_target_weight`: float of update target weight (tau parameter).
     * `double_dqn`: boolean indicating whether to use double-dqn.
-    * `clip_gradients`: float of maximum values for gradients before clipping.
+    * `clip_loss`: float if not 0, uses the huber loss with clip_loss as the linear bound
 
     """
 

--- a/tensorforce/agents/naf_agent.py
+++ b/tensorforce/agents/naf_agent.py
@@ -64,7 +64,7 @@ class NAFAgent(MemoryAgent):
 
     * `target_update_frequency`: int of states between updates of the target network.
     * `update_target_weight`: float of update target weight (tau parameter).
-    * `clip_gradients`: float of maximum values for gradients before clipping.
+    * `clip_loss`: float if not 0, uses the huber loss with clip_loss as the linear bound
 
     """
 


### PR DESCRIPTION
Fixes an error where the target variables actually referenced the training variables so the target network would never be updated.

Changed gradient_clipping -> clip_loss to match with @AlexKuhnle changes to q model.