### PR TITLE
Initial TensorFlow summaries support

### DIFF
--- a/tensorforce/agents/categorical_dqn_agent.py
+++ b/tensorforce/agents/categorical_dqn_agent.py
@@ -55,7 +55,9 @@ class CategoricalDQNAgent(DQNAgent):
     * `optimizer`: string of optimizer to use (e.g. 'adam').
     * `device`: string of tensorflow device name.
     * `tf_saver`: boolean whether to save model parameters.
-    * `tf_summary`: boolean indicating whether to use tensorflow summary file writer.
+    * `tf_summary`: string directory to write tensorflow summaries. Default None
+    * `tf_summary_level`: int indicating which tensorflow summaries to create.
+    * `tf_summary_interval`: int number of calls to get_action until writing tensorflow summaries on update.
     * `log_level`: string containing logleve (e.g. 'info').
     * `distributed`: boolean indicating whether to use distributed tensorflow.
     * `global_model`: global model.

--- a/tensorforce/agents/dqfd_agent.py
+++ b/tensorforce/agents/dqfd_agent.py
@@ -50,7 +50,9 @@ class DQFDAgent(MemoryAgent):
     * `learning_rate`: float of learning rate (alpha).
     * `optimizer`: string of optimizer to use (e.g. 'adam').
     * `device`: string of tensorflow device name.
-    * `tf_summary`: boolean indicating whether to use tensorflow summary file writer.
+    * `tf_summary`: string directory to write tensorflow summaries. Default None
+    * `tf_summary_level`: int indicating which tensorflow summaries to create.
+    * `tf_summary_interval`: int number of calls to get_action until writing tensorflow summaries on update.
     * `log_level`: string containing logleve (e.g. 'info').
     * `distributed`: boolean indicating whether to use distributed tensorflow.
     * `global_model`: global model.

--- a/tensorforce/agents/dqn_agent.py
+++ b/tensorforce/agents/dqn_agent.py
@@ -59,7 +59,9 @@ class DQNAgent(MemoryAgent):
     * `learning_rate`: float of learning rate (alpha).
     * `optimizer`: string of optimizer to use (e.g. 'adam').
     * `device`: string of tensorflow device name.
-    * `tf_summary`: boolean indicating whether to use tensorflow summary file writer.
+    * `tf_summary`: string directory to write tensorflow summaries. Default None
+    * `tf_summary_level`: int indicating which tensorflow summaries to create.
+    * `tf_summary_interval`: int number of calls to get_action until writing tensorflow summaries on update.
     * `log_level`: string containing logleve (e.g. 'info').
     * `distributed`: boolean indicating whether to use distributed tensorflow.
     * `global_model`: global model.

--- a/tensorforce/agents/naf_agent.py
+++ b/tensorforce/agents/naf_agent.py
@@ -54,7 +54,9 @@ class NAFAgent(MemoryAgent):
     * `learning_rate`: float of learning rate (alpha).
     * `optimizer`: string of optimizer to use (e.g. 'adam').
     * `device`: string of tensorflow device name.
-    * `tf_summary`: boolean indicating whether to use tensorflow summary file writer.
+    * `tf_summary`: string directory to write tensorflow summaries. Default None
+    * `tf_summary_level`: int indicating which tensorflow summaries to create.
+    * `tf_summary_interval`: int number of calls to get_action until writing tensorflow summaries on update.
     * `log_level`: string containing logleve (e.g. 'info').
     * `distributed`: boolean indicating whether to use distributed tensorflow.
     * `global_model`: global model.

--- a/tensorforce/core/networks/layers.py
+++ b/tensorforce/core/networks/layers.py
@@ -33,7 +33,7 @@ import tensorflow as tf
 from tensorforce import TensorForceError, util
 
 
-def flatten(x):
+def flatten(x, **kwargs):
     """Flatten layer.
 
     Args:
@@ -48,7 +48,7 @@ def flatten(x):
     return x
 
 
-def nonlinearity(x, name='relu'):
+def nonlinearity(x, name='relu', summary_level=0, **kwargs):
     """ Applies a non-linearity to an input and returns the result.
 
     Args:
@@ -64,6 +64,9 @@ def nonlinearity(x, name='relu'):
             x = tf.nn.elu(features=x)
         elif name == 'relu':
             x = tf.nn.relu(features=x)
+            if summary_level >= 2:
+                non_zero_pct = (tf.cast(tf.count_nonzero(x), tf.float32) / tf.cast(tf.reduce_prod(tf.shape(x)), tf.float32))
+                tf.summary.scalar('relu-sparsity', 1.0 - non_zero_pct)
         elif name == 'selu':
             # https://arxiv.org/pdf/1706.02515.pdf
             alpha = 1.6732632423543772848170429916717
@@ -82,7 +85,7 @@ def nonlinearity(x, name='relu'):
     return x
 
 
-def linear(x, size, weights=None, bias=True, l2_regularization=0.0):
+def linear(x, size, weights=None, bias=True, l2_regularization=0.0, trainable=True, summary_level=0):
     """
     Linear layer.
 
@@ -127,7 +130,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0):
                 raise TensorForceError('Bias shape {} does not match expected shape {} '
                                        .format(bias.shape, shape))
 
-        weights = tf.Variable(initial_value=weights, dtype=tf.float32)
+        weights = tf.Variable(initial_value=weights, dtype=tf.float32, name='W', trainable=trainable)
 
         if l2_regularization > 0.0:
             tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=weights))
@@ -135,7 +138,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0):
         x = tf.matmul(a=x, b=weights)
 
         if bias is not None:
-            bias = tf.Variable(initial_value=bias, dtype=tf.float32)
+            bias = tf.Variable(initial_value=bias, dtype=tf.float32, name='b', trainable=trainable)
             if l2_regularization > 0.0:
                 tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=bias))
             x = tf.nn.bias_add(value=x, bias=bias)
@@ -143,7 +146,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0):
     return x
 
 
-def dense(x, size, bias=True, activation='relu', l2_regularization=0.0):
+def dense(x, size, bias=True, activation='relu', l2_regularization=0.0, trainable=True, summary_level=0):
     """
     Fully connected layer.
 
@@ -163,13 +166,14 @@ def dense(x, size, bias=True, activation='relu', l2_regularization=0.0):
                                ' must be 2.'.format(input_rank))
 
     with tf.variable_scope('dense'):
-        x = linear(x=x, size=size, bias=bias, l2_regularization=l2_regularization)
-        x = nonlinearity(x=x, name=activation)
+        x = linear(x=x, size=size, bias=bias, l2_regularization=l2_regularization, trainable=trainable)
+        x = nonlinearity(x=x, name=activation, summary_level=summary_level)
 
     return x
 
 
-def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regularization=0.0):
+def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regularization=0.0, trainable=True,
+           summary_level=0):
     """A 2d convolutional layer.
 
     Args:
@@ -191,7 +195,7 @@ def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regula
     with tf.variable_scope('conv2d'):
         shape = (window, window, x.shape[3].value, size)
         stddev = min(0.1, sqrt(2.0 / size))
-        filters = tf.Variable(initial_value=tf.random_normal(shape=shape, stddev=stddev))
+        filters = tf.Variable(initial_value=tf.random_normal(shape=shape, stddev=stddev), name='W', trainable=trainable)
 
         if l2_regularization > 0.0:
             tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=filters))
@@ -200,17 +204,17 @@ def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regula
         x = tf.nn.conv2d(input=x, filter=filters, strides=strides, padding='SAME')
 
         if bias:
-            bias = tf.Variable(initial_value=tf.zeros(shape=(size,)))
+            bias = tf.Variable(initial_value=tf.zeros(shape=(size,)), name='b', trainable=trainable)
             if l2_regularization > 0.0:
                 tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=bias))
             x = tf.nn.bias_add(value=x, bias=bias)
 
-        x = nonlinearity(x=x, name=activation)
+        x = nonlinearity(x=x, name=activation, summary_level=summary_level)
 
     return x
 
 
-def lstm(x, size=None):
+def lstm(x, size=None, **kwargs):
     """
 
     Args:
@@ -262,7 +266,7 @@ def layered_network_builder(layers_config):
 
     """
 
-    def network_builder(inputs):
+    def network_builder(inputs, trainable=True, summary_level=0):
         input_length = len(inputs)
 
         if input_length != 1:
@@ -277,7 +281,7 @@ def layered_network_builder(layers_config):
             x = util.get_object(
                 obj=layer_config,
                 predefined=layers,
-                kwargs=dict(x=x)
+                kwargs=dict(x=x, trainable=trainable, summary_level=summary_level)
             )
             if isinstance(x, list) or isinstance(x, tuple):
                 assert len(x) == 4

--- a/tensorforce/core/networks/layers.py
+++ b/tensorforce/core/networks/layers.py
@@ -85,7 +85,7 @@ def nonlinearity(x, name='relu', summary_level=0, **kwargs):
     return x
 
 
-def linear(x, size, weights=None, bias=True, l2_regularization=0.0, trainable=True, summary_level=0):
+def linear(x, size, weights=None, bias=True, l2_regularization=0.0, summary_level=0):
     """
     Linear layer.
 
@@ -130,7 +130,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0, trainable=Tr
                 raise TensorForceError('Bias shape {} does not match expected shape {} '
                                        .format(bias.shape, shape))
 
-        weights = tf.Variable(initial_value=weights, dtype=tf.float32, name='W', trainable=trainable)
+        weights = tf.Variable(initial_value=weights, dtype=tf.float32, name='W')
 
         if l2_regularization > 0.0:
             tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=weights))
@@ -138,7 +138,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0, trainable=Tr
         x = tf.matmul(a=x, b=weights)
 
         if bias is not None:
-            bias = tf.Variable(initial_value=bias, dtype=tf.float32, name='b', trainable=trainable)
+            bias = tf.Variable(initial_value=bias, dtype=tf.float32, name='b')
             if l2_regularization > 0.0:
                 tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=bias))
             x = tf.nn.bias_add(value=x, bias=bias)
@@ -146,7 +146,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0, trainable=Tr
     return x
 
 
-def dense(x, size, bias=True, activation='relu', l2_regularization=0.0, trainable=True, summary_level=0):
+def dense(x, size, bias=True, activation='relu', l2_regularization=0.0, summary_level=0):
     """
     Fully connected layer.
 
@@ -166,13 +166,13 @@ def dense(x, size, bias=True, activation='relu', l2_regularization=0.0, trainabl
                                ' must be 2.'.format(input_rank))
 
     with tf.variable_scope('dense'):
-        x = linear(x=x, size=size, bias=bias, l2_regularization=l2_regularization, trainable=trainable)
+        x = linear(x=x, size=size, bias=bias, l2_regularization=l2_regularization)
         x = nonlinearity(x=x, name=activation, summary_level=summary_level)
 
     return x
 
 
-def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regularization=0.0, trainable=True,
+def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regularization=0.0,
            summary_level=0):
     """A 2d convolutional layer.
 
@@ -195,7 +195,7 @@ def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regula
     with tf.variable_scope('conv2d'):
         shape = (window, window, x.shape[3].value, size)
         stddev = min(0.1, sqrt(2.0 / size))
-        filters = tf.Variable(initial_value=tf.random_normal(shape=shape, stddev=stddev), name='W', trainable=trainable)
+        filters = tf.Variable(initial_value=tf.random_normal(shape=shape, stddev=stddev), name='W')
 
         if l2_regularization > 0.0:
             tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=filters))
@@ -204,7 +204,7 @@ def conv2d(x, size, window=3, stride=1, bias=False, activation='relu', l2_regula
         x = tf.nn.conv2d(input=x, filter=filters, strides=strides, padding='SAME')
 
         if bias:
-            bias = tf.Variable(initial_value=tf.zeros(shape=(size,)), name='b', trainable=trainable)
+            bias = tf.Variable(initial_value=tf.zeros(shape=(size,)), name='b')
             if l2_regularization > 0.0:
                 tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=bias))
             x = tf.nn.bias_add(value=x, bias=bias)
@@ -266,7 +266,7 @@ def layered_network_builder(layers_config):
 
     """
 
-    def network_builder(inputs, trainable=True, summary_level=0):
+    def network_builder(inputs, summary_level=0):
         input_length = len(inputs)
 
         if input_length != 1:
@@ -281,7 +281,7 @@ def layered_network_builder(layers_config):
             x = util.get_object(
                 obj=layer_config,
                 predefined=layers,
-                kwargs=dict(x=x, trainable=trainable, summary_level=summary_level)
+                kwargs=dict(x=x, summary_level=summary_level)
             )
             if isinstance(x, list) or isinstance(x, tuple):
                 assert len(x) == 4

--- a/tensorforce/core/networks/network.py
+++ b/tensorforce/core/networks/network.py
@@ -27,14 +27,14 @@ import tensorflow as tf
 
 class NeuralNetwork(object):
 
-    def __init__(self, network_builder, inputs, trainable=True, summary_level=0):
+    def __init__(self, network_builder, inputs, summary_level=0):
         """
 
         Args:
             network_builder: A network_builder function representing the desired network configuration
             inputs: Input placeholders to the network
         """
-        network = network_builder(inputs, trainable=trainable, summary_level=summary_level)
+        network = network_builder(inputs, summary_level=summary_level)
 
         if isinstance(network, tf.Tensor):
             self.output = network

--- a/tensorforce/core/networks/network.py
+++ b/tensorforce/core/networks/network.py
@@ -27,14 +27,14 @@ import tensorflow as tf
 
 class NeuralNetwork(object):
 
-    def __init__(self, network_builder, inputs):
+    def __init__(self, network_builder, inputs, trainable=True, summary_level=0):
         """
 
         Args:
             network_builder: A network_builder function representing the desired network configuration
             inputs: Input placeholders to the network
         """
-        network = network_builder(inputs)
+        network = network_builder(inputs, trainable=trainable, summary_level=summary_level)
 
         if isinstance(network, tf.Tensor):
             self.output = network

--- a/tensorforce/models/categorical_dqn_model.py
+++ b/tensorforce/models/categorical_dqn_model.py
@@ -100,12 +100,12 @@ class CategoricalDQNModel(Model):
 
         # Target network
         with tf.variable_scope('target') as target_scope:
-            self.target_network = NeuralNetwork(network_builder=network_builder, inputs=self.next_state, trainable=False)
+            self.target_network = NeuralNetwork(network_builder=network_builder, inputs=self.next_state)
             self.internal_inputs.extend(self.target_network.internal_inputs)
             self.internal_outputs.extend(self.target_network.internal_outputs)
             self.internal_inits.extend(self.target_network.internal_inits)
             _, target_output_probabilities, target_qval, target_action = self._create_action_outputs(
-                self.target_network.output, quantized_steps, self.num_atoms, config, self.action, num_actions, trainable=False
+                self.target_network.output, quantized_steps, self.num_atoms, config, self.action, num_actions
             )
 
             self.target_variables = tf.contrib.framework.get_variables(scope=target_scope)
@@ -206,7 +206,7 @@ class CategoricalDQNModel(Model):
         self.session.run(self.target_network_update)
 
     @staticmethod
-    def _create_action_outputs(network_output, quantized_steps, num_atoms, config, actions, num_actions, trainable=True):
+    def _create_action_outputs(network_output, quantized_steps, num_atoms, config, actions, num_actions):
         action_logits = dict()
         action_probabilities = dict()
         action_qvals = dict()
@@ -225,7 +225,7 @@ class CategoricalDQNModel(Model):
                 actions_and_logits = []
                 actions_and_probabilities = []
                 for action_ind in range(num_actions[action]):
-                    logits_output = layers['linear'](x=network_output, size=num_atoms, trainable=trainable)
+                    logits_output = layers['linear'](x=network_output, size=num_atoms)
                     # logits are stored for use in loss function
                     actions_and_logits.append(logits_output)
                     # softmax

--- a/tensorforce/models/dqn_model.py
+++ b/tensorforce/models/dqn_model.py
@@ -42,7 +42,7 @@ class DQNModel(QModel):
         """Training logic for DQN.
 
         Args:
-            config: 
+            config:
         """
         config.default(DQNModel.default_config)
         super(DQNModel, self).__init__(config)
@@ -63,6 +63,22 @@ class DQNModel(QModel):
 
             one_hot = tf.one_hot(indices=action, depth=num_actions)
             q_values[name] = tf.reduce_sum(input_tensor=(output * one_hot), axis=-1)
+            # Summaries for output
+            if config.tf_summary_level >= 1:
+                # multi action output
+                if flat_size > 1:
+                    for action_ind in range(flat_size):
+                        for real_action in range(num_actions):
+                            action_name = name + '-{}-{}'.format(action_ind, real_action)
+                            if len(output.shape) == 4:
+                                tf.summary.histogram(action_name, output[:, :, action_ind, real_action])
+                            else:
+                                tf.summary.histogram(action_name, output[:, action_ind, real_action])
+                # else single index output
+                else:
+                    for real_action in range(num_actions):
+                        action_name = name + '-{}'.format(real_action)
+                        tf.summary.histogram(action_name, output[:, real_action])
 
         return q_values
 
@@ -73,7 +89,7 @@ class DQNModel(QModel):
             num_actions = config.actions[name].num_actions
             shape = (-1,) + config.actions[name].shape + (num_actions,)
 
-            output = layers['linear'](x=self.target_network.output, size=(flat_size * num_actions))
+            output = layers['linear'](x=self.target_network.output, size=(flat_size * num_actions), trainable=False)
             output = tf.reshape(tensor=output, shape=shape)
 
             if config.double_dqn:

--- a/tensorforce/models/dqn_model.py
+++ b/tensorforce/models/dqn_model.py
@@ -89,7 +89,7 @@ class DQNModel(QModel):
             num_actions = config.actions[name].num_actions
             shape = (-1,) + config.actions[name].shape + (num_actions,)
 
-            output = layers['linear'](x=self.target_network.output, size=(flat_size * num_actions), trainable=False)
+            output = layers['linear'](x=self.target_network.output, size=(flat_size * num_actions))
             output = tf.reshape(tensor=output, shape=shape)
 
             if config.double_dqn:

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -40,7 +40,9 @@ class Model(object):
     * `learning_rate`: float of learning rate (alpha).
     * `optimizer`: string of optimizer to use (e.g. 'adam').
     * `device`: string of tensorflow device name.
-    * `tf_summary`: boolean indicating whether to use tensorflow summary file writer.
+    * `tf_summary`: string directory to write tensorflow summaries. Default None
+    * `tf_summary_level`: int indicating which tensorflow summaries to create.
+    * `tf_summary_interval`: int number of calls to get_action until writing tensorflow summaries on update.
     * `log_level`: string containing log level (e.g. 'info').
     * `distributed`: boolean indicating whether to use distributed tensorflow.
     * `global_model`: global model.

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -92,7 +92,7 @@ class Model(object):
             global_config.global_model = True
             global_config.device = tf.train.replica_device_setter(1, worker_device=config.device, cluster=config.cluster_spec)
             self.global_model = self.__class__(config=global_config)
-            self.global_timestep = self.global_model.timestep
+            self.global_timestep = self.global_model.global_timestep
             self.global_episode = self.global_model.episode
             self.global_variables = self.global_model.variables
 
@@ -100,7 +100,7 @@ class Model(object):
         with tf.device(config.device):
             if config.distributed:
                 if config.global_model:
-                    self.timestep = tf.get_variable(name='timestep', dtype=tf.int32, initializer=0, trainable=False)
+                    self.global_timestep = tf.get_variable(name='timestep', dtype=tf.int32, initializer=0, trainable=False)
                     self.episode = tf.get_variable(name='episode', dtype=tf.int32, initializer=0, trainable=False)
                     scope_context = tf.variable_scope('global')
                 else:

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -69,7 +69,7 @@ class QModel(Model):
 
         # Target network
         with tf.variable_scope('target') as target_scope:
-            self.target_network = NeuralNetwork(network_builder=network_builder, inputs=self.next_state, trainable=False)
+            self.target_network = NeuralNetwork(network_builder=network_builder, inputs=self.next_state)
             self.internal_inputs.extend(self.target_network.internal_inputs)
             self.internal_outputs.extend(self.target_network.internal_outputs)
             self.internal_inits.extend(self.target_network.internal_inits)

--- a/tensorforce/tests/test_categorical_dqn_agent.py
+++ b/tensorforce/tests/test_categorical_dqn_agent.py
@@ -65,7 +65,7 @@ class TestCategoricalDQNAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)

--- a/tensorforce/tests/test_dqfd_agent.py
+++ b/tensorforce/tests/test_dqfd_agent.py
@@ -84,7 +84,7 @@ class TestDQFDAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)

--- a/tensorforce/tests/test_dqn_agent.py
+++ b/tensorforce/tests/test_dqn_agent.py
@@ -65,7 +65,7 @@ class TestDQNAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)

--- a/tensorforce/tests/test_naf_agent.py
+++ b/tensorforce/tests/test_naf_agent.py
@@ -50,7 +50,7 @@ class TestNAFAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)

--- a/tensorforce/tests/test_ppo_agent.py
+++ b/tensorforce/tests/test_ppo_agent.py
@@ -100,7 +100,7 @@ class TestPPOAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)

--- a/tensorforce/tests/test_trpo_agent.py
+++ b/tensorforce/tests/test_trpo_agent.py
@@ -92,7 +92,7 @@ class TestTRPOAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)

--- a/tensorforce/tests/test_tutorial_code.py
+++ b/tensorforce/tests/test_tutorial_code.py
@@ -190,7 +190,7 @@ class TestTutorialCode(unittest.TestCase):
 
         ### Code block: Own layer type
 
-        def batch_normalization(x, variance_epsilon=1e-6):
+        def batch_normalization(x, variance_epsilon=1e-6, **kwargs):
             mean, variance = tf.nn.moments(x, axes=tuple(range(x.shape.ndims - 1)))
             x = tf.nn.batch_normalization(x, mean=mean, variance=variance, offset=None, scale=None,
                                           variance_epsilon=variance_epsilon)
@@ -207,7 +207,7 @@ class TestTutorialCode(unittest.TestCase):
 
         ### Code block: Own network builder
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             image = inputs['image']  # 64x64x3-dim, float
             caption = inputs['caption']  # 20-dim, int
 
@@ -245,7 +245,7 @@ class TestTutorialCode(unittest.TestCase):
 
         ### Code block: LSTM function
 
-        def lstm(x):
+        def lstm(x, **kwargs):
             size = x.get_shape()[1].value
             internal_input = tf.placeholder(dtype=tf.float32, shape=(None, 2, size))
             lstm = tf.contrib.rnn.LSTMCell(num_units=size)

--- a/tensorforce/tests/test_vpg_agent.py
+++ b/tensorforce/tests/test_vpg_agent.py
@@ -91,7 +91,7 @@ class TestVPGAgent(unittest.TestCase):
     def test_multi(self):
         passed = 0
 
-        def network_builder(inputs):
+        def network_builder(inputs, **kwargs):
             layer = layers['dense']
             state0 = layer(x=layer(x=inputs['state0'], size=32), size=32)
             state1 = layer(x=layer(x=inputs['state1'], size=32), size=32)


### PR DESCRIPTION
Adds tf_summary_level and tf_summary_interval to configs.
Adds a timestep in model that's incremented each call to get_action
Supports loss, trainable variables and action outputs.

The summary levels I had imagined are as follows:

0. Loss/Loss per action, these summaries are always created so they don't check config.tf_summary_level
1. Network Output, Q values for DQN. I'm not very familiar with policy gradient methods so I wasn't sure what output summary would be most useful and thus didn't write any
2. Trainable Variables, target networks is why I had to add a trainable flag into the layer constructor. The easy way to do this was using tf.trainable_variables, but it could be done in the layer functions and that would remove the need for the trainable flag.