### PR TITLE
DropoutWrapper output_keep_prob=1-dropout, not =dropout

### DIFF
--- a/tensorforce/core/networks/layers.py
+++ b/tensorforce/core/networks/layers.py
@@ -257,7 +257,7 @@ def lstm(x, size=None, dropout=None, scope='lstm', summary_level=0):
         internal_input = tf.placeholder(dtype=tf.float32, shape=(None, 2, size))
         lstm_cell = tf.contrib.rnn.LSTMCell(num_units=size)
         if dropout:
-            lstm_cell = tf.contrib.rnn.DropoutWrapper(lstm_cell, output_keep_prob=dropout)
+            lstm_cell = tf.contrib.rnn.DropoutWrapper(lstm_cell, output_keep_prob=1 - dropout)
         c = internal_input[:, 0, :]
         h = internal_input[:, 1, :]
         state = tf.contrib.rnn.LSTMStateTuple(c=c, h=h)


### PR DESCRIPTION
Sorry guys, I may have gotten https://github.com/reinforceio/tensorforce/pull/110 wrong - I think `output_keep_prob` is supposed to be the _opposite_ (or just rename the function arg to `output_keep_prob`). Double check my sanity if you could: [usage](https://www.tensorflow.org/api_docs/python/tf/contrib/rnn/DropoutWrapper#__init__)