### PR TITLE
allow passing custom tensorflow session config

### DIFF
--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -167,7 +167,7 @@ class Model(object):
         self.summary_interval = config.tf_summary_interval
 
         if not config.distributed:
-            self.set_session(tf.Session())
+            self.set_session(tf.Session(config=config.get('tf_session_config', {})))
             self.session.run(tf.global_variables_initializer())
             tf.get_default_graph().finalize()
 


### PR DESCRIPTION
I like sometimes training a couple models on my one 1080ti, allocating 1/3 GPU memory for training 3 separate models (for performance comparison), or 1/2 for 2. Or sometimes 1/2 for 2 main trainers, and CPU-only for some code debugging in Pycharm. Normally I do:

```python
# 1/3 GPU memory for this training session
tf_config = tf.ConfigProto(gpu_options=tf.GPUOptions(per_process_gpu_memory_fraction=1/3))
# CPU-only
tf_config = tf.ConfigProto(device_count={'GPU': 0})

self.set_session(tf.Session(config=tf_config))
```

Would y'all be amenable to passing that in as a config? I could create my own session, but I like all the other session-creation stuff y'all have going on in that code block. Feel free to close if there's a better way.