### PR TITLE
Add reward preprocessing to base Agent

### DIFF
--- a/examples/ale.py
+++ b/examples/ale.py
@@ -42,7 +42,6 @@ def main():
     parser.add_argument('-c', '--agent-config', help="Agent configuration file")
     parser.add_argument('-n', '--network-config', help="Network configuration file")
     parser.add_argument('-fs', '--frame-skip', help="Number of frames to repeat action", type=int, default=1)
-    parser.add_argument('-rc', '--reward-clipping', help="Reward clipping. EX: -1 1", nargs="+", type=float)
     parser.add_argument('-rap', '--repeat-action-probability', help="Repeat action probability", type=float, default=0.0)
     parser.add_argument('-lolt', '--loss-of-life-termination', help="Loss of life counts as terminal state", action='store_true')
     parser.add_argument('-lolr', '--loss-of-life-reward', help="Loss of life reward/penalty. EX: -1 to penalize", type=float, default=0.0)
@@ -60,7 +59,7 @@ def main():
     logger.setLevel(logging.DEBUG)  # configurable!!!
     logger.addHandler(logging.StreamHandler(sys.stdout))
 
-    environment = ALE(args.rom, frame_skip=args.frame_skip, reward_clipping=args.reward_clipping,
+    environment = ALE(args.rom, frame_skip=args.frame_skip,
                       repeat_action_probability=args.repeat_action_probability,
                       loss_of_life_termination=args.loss_of_life_termination,
                       loss_of_life_reward=args.loss_of_life_reward,

--- a/examples/configs/dqfd_agent.json
+++ b/examples/configs/dqfd_agent.json
@@ -40,6 +40,13 @@
       "length": 4
     }
   ],
+  "reward_preprocessing": [
+    {
+      "type": "clip",
+      "min": -1,
+      "max": 1
+    }
+  ],
   "repeat_actions": 1,
   "alpha": 0.00025,
   "gamma": 0.99,

--- a/examples/configs/dqn_agent.json
+++ b/examples/configs/dqn_agent.json
@@ -6,6 +6,13 @@
     "epsilon_final": 0.1,
     "epsilon_timesteps": 1e6
   },
+  "reward_preprocessing": [
+    {
+      "type": "clip",
+      "min": -1,
+      "max": 1
+    }
+  ],
 
   "batch_size": 32,
   "memory_capacity": 10000,

--- a/examples/configs/dqn_agent_visual.json
+++ b/examples/configs/dqn_agent_visual.json
@@ -22,6 +22,13 @@
     "epsilon_final": 0.1,
     "epsilon_timesteps": 1e6
   },
+  "reward_preprocessing": [
+    {
+      "type": "clip",
+      "min": -1,
+      "max": 1
+    }
+  ],
 
   "batch_size": 32,
   "memory_capacity": 10000,

--- a/examples/configs/dqn_nstep_agent_visual.json
+++ b/examples/configs/dqn_nstep_agent_visual.json
@@ -23,6 +23,13 @@
     "epsilon_final": 0.1,
     "epsilon_timesteps": 1e6
   },
+  "reward_preprocessing": [
+    {
+      "type": "clip",
+      "min": -1,
+      "max": 1
+    }
+  ],
 
   "batch_size": 6,
   "repeat_update": 1,

--- a/examples/configs/dqn_universe.json
+++ b/examples/configs/dqn_universe.json
@@ -37,8 +37,15 @@
       "length": 4
     }
   ],
+  "reward_preprocessing": [
+    {
+      "type": "clip",
+      "min": -1,
+      "max": 1
+    }
+  ],
   "repeat_actions": 1,
-  
+
   "network_layers": [
     {
       "type": "conv2d",
@@ -60,5 +67,5 @@
       "size": 16
     }
   ]
-  
+
 }

--- a/examples/threaded_ale.py
+++ b/examples/threaded_ale.py
@@ -54,7 +54,6 @@ def main():
     parser.add_argument('-n', '--network-config', help="Network configuration file")
     parser.add_argument('-w', '--workers', help="Number of threads to run where the model is shared", type=int, default=16)
     parser.add_argument('-fs', '--frame-skip', help="Number of frames to repeat action", type=int, default=1)
-    parser.add_argument('-rc', '--reward-clipping', help="Reward clipping. EX: -1 1", nargs="+", type=float)
     parser.add_argument('-rap', '--repeat-action-probability', help="Repeat action probability", type=float, default=0.0)
     parser.add_argument('-lolt', '--loss-of-life-termination', help="Loss of life counts as terminal state", action='store_true')
     parser.add_argument('-lolr', '--loss-of-life-reward', help="Loss of life reward/penalty. EX: -1 to penalize", type=float, default=0.0)
@@ -73,7 +72,7 @@ def main():
     logger.setLevel(logging.DEBUG)  # configurable!!!
     logger.addHandler(logging.StreamHandler(sys.stdout))
 
-    environments = [ALE(args.rom, frame_skip=args.frame_skip, reward_clipping=args.reward_clipping,
+    environments = [ALE(args.rom, frame_skip=args.frame_skip,
                         repeat_action_probability=args.repeat_action_probability,
                         loss_of_life_termination=args.loss_of_life_termination,
                         loss_of_life_reward=args.loss_of_life_reward,

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -242,24 +242,20 @@ class Agent(object):
     def observe(self, reward, terminal):
         """
         Observe experience from the environment to learn from. Optionally preprocesses rewards
-        Child classes should override _observe
+        Child classes should call super to get the processed reward
+        EX: reward, terminal = super()...
 
         Args:
             reward: scalar reward that resulted from executing the action.
             terminal: boolean indicating if the episode terminated after the observation.
 
         Returns:
-            void
-
+            processed_reward
+            terminal
         """
         if self.reward_preprocessing is not None:
             reward = self.reward_preprocessing.process(reward)
-        self._observe(reward, terminal)
-
-    def _observe(self, reward, terminal):
-        """ Child classes should override this method
-        """
-        raise NotImplementedError
+        return reward, terminal
 
     def observe_episode_reward(self, episode_reward):
         if self.model:

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -92,6 +92,7 @@ class Agent(object):
     default_config = dict(
         preprocessing=None,
         exploration=None,
+        reward_preprocessing=None,
         log_level='info'
     )
 
@@ -148,6 +149,11 @@ class Agent(object):
                 action.shape = (action.shape,)
             if config.exploration is not None and name in config.exploration:
                 self.exploration[name] = Exploration.from_config(config=config.exploration[name])
+
+        # reward preprocessing config
+        self.reward_preprocessing = None
+        if config.reward_preprocessing is not None:
+            self.reward_preprocessing = Preprocessing.from_config(config=config.reward_preprocessing)
 
         self.states_config = config.states
         self.actions_config = config.actions
@@ -234,7 +240,9 @@ class Agent(object):
             return self.current_action
 
     def observe(self, reward, terminal):
-        """Observe experience from the environment to learn from.
+        """
+        Observe experience from the environment to learn from. Optionally preprocesses rewards
+        Child classes should override _observe
 
         Args:
             reward: scalar reward that resulted from executing the action.
@@ -243,6 +251,13 @@ class Agent(object):
         Returns:
             void
 
+        """
+        if self.reward_preprocessing is not None:
+            reward = self.reward_preprocessing.process(reward)
+        self._observe(reward, terminal)
+
+    def _observe(self, reward, terminal):
+        """ Child classes should override this method
         """
         raise NotImplementedError
 

--- a/tensorforce/agents/batch_agent.py
+++ b/tensorforce/agents/batch_agent.py
@@ -54,7 +54,7 @@ class BatchAgent(Agent):
         self.keep_last = config.keep_last
         super(BatchAgent, self).__init__(config, model)
 
-    def observe(self, reward, terminal):
+    def _observe(self, reward, terminal):
         """
         Adds an observation and performs an update if the necessary conditions
         are satisfied, i.e. if one batch of experience has been collected as defined

--- a/tensorforce/agents/batch_agent.py
+++ b/tensorforce/agents/batch_agent.py
@@ -54,7 +54,7 @@ class BatchAgent(Agent):
         self.keep_last = config.keep_last
         super(BatchAgent, self).__init__(config, model)
 
-    def _observe(self, reward, terminal):
+    def observe(self, reward, terminal):
         """
         Adds an observation and performs an update if the necessary conditions
         are satisfied, i.e. if one batch of experience has been collected as defined
@@ -69,6 +69,7 @@ class BatchAgent(Agent):
 
         Returns: void
         """
+        reward, terminal = super(BatchAgent, self).observe(reward, terminal)
         self.current_reward = reward
         self.current_terminal = terminal
 

--- a/tensorforce/agents/dqfd_agent.py
+++ b/tensorforce/agents/dqfd_agent.py
@@ -102,7 +102,7 @@ class DQFDAgent(MemoryAgent):
         self.demo_batch_size = int(config.demo_sampling_ratio * config.batch_size / (1.0 - config.demo_sampling_ratio))
         assert self.demo_batch_size > 0, 'Check DQFD sampling parameters to make sure demo_batch_size is positive. (Calculated {} based on current parameters)'.format(self.demo_batch_size)
 
-    def observe(self, reward, terminal):
+    def _observe(self, reward, terminal):
         """Adds observations, updates via sampling from memories according to update rate.
         DQFD samples from the online replay memory and the demo memory with
         the fractions controlled by a hyper parameter p called 'expert sampling ratio.
@@ -114,7 +114,7 @@ class DQFDAgent(MemoryAgent):
         Returns:
 
         """
-        super(DQFDAgent, self).observe(reward=reward, terminal=terminal)
+        super(DQFDAgent, self)._observe(reward=reward, terminal=terminal)
 
         if self.timestep >= self.first_update and self.timestep % self.update_frequency == 0:
             for _ in xrange(self.repeat_update):

--- a/tensorforce/agents/dqfd_agent.py
+++ b/tensorforce/agents/dqfd_agent.py
@@ -102,7 +102,7 @@ class DQFDAgent(MemoryAgent):
         self.demo_batch_size = int(config.demo_sampling_ratio * config.batch_size / (1.0 - config.demo_sampling_ratio))
         assert self.demo_batch_size > 0, 'Check DQFD sampling parameters to make sure demo_batch_size is positive. (Calculated {} based on current parameters)'.format(self.demo_batch_size)
 
-    def _observe(self, reward, terminal):
+    def observe(self, reward, terminal):
         """Adds observations, updates via sampling from memories according to update rate.
         DQFD samples from the online replay memory and the demo memory with
         the fractions controlled by a hyper parameter p called 'expert sampling ratio.
@@ -114,7 +114,7 @@ class DQFDAgent(MemoryAgent):
         Returns:
 
         """
-        super(DQFDAgent, self)._observe(reward=reward, terminal=terminal)
+        super(DQFDAgent, self).observe(reward=reward, terminal=terminal)
 
         if self.timestep >= self.first_update and self.timestep % self.update_frequency == 0:
             for _ in xrange(self.repeat_update):

--- a/tensorforce/agents/memory_agent.py
+++ b/tensorforce/agents/memory_agent.py
@@ -74,7 +74,7 @@ class MemoryAgent(Agent):
         self.first_update = config.first_update
         self.repeat_update = config.repeat_update
 
-    def observe(self, reward, terminal):
+    def _observe(self, reward, terminal):
         self.current_reward = reward
         self.current_terminal = terminal
 

--- a/tensorforce/agents/memory_agent.py
+++ b/tensorforce/agents/memory_agent.py
@@ -74,7 +74,8 @@ class MemoryAgent(Agent):
         self.first_update = config.first_update
         self.repeat_update = config.repeat_update
 
-    def _observe(self, reward, terminal):
+    def observe(self, reward, terminal):
+        reward, terminal = super(MemoryAgent, self).observe(reward, terminal)
         self.current_reward = reward
         self.current_terminal = terminal
 

--- a/tensorforce/agents/random_agent.py
+++ b/tensorforce/agents/random_agent.py
@@ -68,7 +68,7 @@ class RandomAgent(Agent):
         else:
             return self.current_action
 
-    def observe(self, reward, terminal):
+    def _observe(self, reward, terminal):
         self.current_reward = reward
         self.current_terminal = terminal
 

--- a/tensorforce/agents/random_agent.py
+++ b/tensorforce/agents/random_agent.py
@@ -68,7 +68,8 @@ class RandomAgent(Agent):
         else:
             return self.current_action
 
-    def _observe(self, reward, terminal):
+    def observe(self, reward, terminal):
+        reward, terminal = super(RandomAgent, self).observe(reward, terminal)
         self.current_reward = reward
         self.current_terminal = terminal
 

--- a/tensorforce/contrib/ale.py
+++ b/tensorforce/contrib/ale.py
@@ -30,7 +30,7 @@ from tensorforce.environments import Environment
 
 class ALE(Environment):
 
-    def __init__(self, rom, frame_skip=1, reward_clipping=None, repeat_action_probability=0.0,
+    def __init__(self, rom, frame_skip=1, repeat_action_probability=0.0,
                  loss_of_life_termination=False, loss_of_life_reward=0, display_screen=False,
                  seed=np.random.RandomState()):
         """
@@ -39,7 +39,6 @@ class ALE(Environment):
         Args:
             rom: Rom filename and directory.
             frame_skip: Repeat action for n frames. Default 1.
-            reward_clipping: Clip rewards between (low, high). Can be None. Default None.
             repeat_action_probability: Repeats last action with given probability. Default 0.
             loss_of_life_termination: Signals a terminal state on loss of life. Default False.
             loss_of_life_reward: Reward/Penalty on loss of life (negative values are a penalty). Default 0.
@@ -75,9 +74,6 @@ class ALE(Environment):
         self.loss_of_life_termination = loss_of_life_termination
         self.life_lost = False
 
-        # reward clipping
-        self.reward_clipping = reward_clipping
-
     def __str__(self):
         return 'ALE({})'.format(self.rom)
 
@@ -105,8 +101,6 @@ class ALE(Environment):
                 self.life_lost = True
                 rew += self.loss_of_life_reward
 
-        if self.reward_clipping is not None:
-            rew = np.clip(rew, self.reward_clipping[0], self.reward_clipping[1])
         terminal = self.is_terminal
         state_tp1 = self.current_state
         return state_tp1, rew, terminal

--- a/tensorforce/core/preprocessing/__init__.py
+++ b/tensorforce/core/preprocessing/__init__.py
@@ -20,6 +20,7 @@ from tensorforce.core.preprocessing.center import Center
 from tensorforce.core.preprocessing.grayscale import Grayscale
 from tensorforce.core.preprocessing.image_resize import ImageResize
 from tensorforce.core.preprocessing.divide import Divide
+from tensorforce.core.preprocessing.clip import Clip
 from tensorforce.core.preprocessing.preprocessing import Preprocessing
 
 
@@ -30,7 +31,9 @@ preprocessors = dict(
     grayscale=Grayscale,
     image_resize=ImageResize,
     divide=Divide,
+    clip=Clip,
 )
 
 
-__all__ = ['Preprocessor', 'Sequence', 'Normalize', 'Center', 'Grayscale', 'ImageResize', 'Preprocessing', 'Divide', 'preprocessors']
+__all__ = ['Preprocessor', 'Sequence', 'Normalize', 'Center', 'Grayscale', 'ImageResize', 'Preprocessing', 'Divide',
+           'Clip', 'preprocessors']

--- a/tensorforce/core/preprocessing/clip.py
+++ b/tensorforce/core/preprocessing/clip.py
@@ -1,0 +1,38 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""
+Clip data by min/max values.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+from tensorforce.core.preprocessing import Preprocessor
+
+
+class Clip(Preprocessor):
+    """
+    Clip by min/max.
+    """
+    def __init__(self, min, max):
+        super(Clip, self).__init__()
+        self.min = min
+        self.max = max
+
+    def process(self, state):
+        return np.clip(state, self.min, self.max)


### PR DESCRIPTION
Reward clipping applies to all DQN/A3C agents that I know of so I think it makes sense to put this in the base Agent class. This change supports any type of reward preprocessing as defined in the preprocessing folder (divide, clip [newly added], etc)

Subclasses of Agent must now override _observe(self, reward, terminal) instead of observe. 

Also removes reward clipping from ALE and updates the DQN config files to include reward clipping [-1, 1]