### PR TITLE
allow_defaults fix in Configuration.from_json()

### DIFF
--- a/tensorforce/config.py
+++ b/tensorforce/config.py
@@ -42,7 +42,7 @@ class Configuration(object):
 
         with open(path, 'r') as fp:
             json_string = fp.read()
-        return Configuration.from_json_string(json_string=json_string, allow_defaults=True)
+        return Configuration.from_json_string(json_string=json_string, allow_defaults=allow_defaults)
 
     @staticmethod
     def from_json_string(json_string, allow_defaults=True):


### PR DESCRIPTION
this method was always allowing defaults rather than passing through the method's argument.