### PR TITLE
[DNM] Distributed fixes

### DIFF
--- a/examples/configs/dqn_nstep_agent_visual.json
+++ b/examples/configs/dqn_nstep_agent_visual.json
@@ -32,7 +32,6 @@
   ],
 
   "batch_size": 6,
-  "repeat_update": 1,
   "keep_last": true,
   "target_update_frequency": 10000,
 
@@ -47,7 +46,6 @@
   "tf_summary": null,
   "log_level": "info",
 
-  "gradient_clipping": 40,
   "update_target_weight": 1.0,
   "double_dqn": false,
   "clip_loss": 1.0

--- a/examples/openai_gym_async.py
+++ b/examples/openai_gym_async.py
@@ -157,6 +157,11 @@ def main():
     logger = logging.getLogger(__name__)
     logger.setLevel(log_levels[agent_config.log_level])
 
+    # don't write summaries for tasks other than chief (0)
+    if args.task_index != 0:
+        agent_config.tf_summary = None
+        agent_config.tf_summary_level = -1
+        logger.info("Summaries disabled for agent {}".format(args.task_index))
     agent = agents[args.agent](config=agent_config)
 
     logger.info("Starting distributed agent for OpenAI Gym '{gym_id}'".format(gym_id=args.gym_id))
@@ -168,7 +173,8 @@ def main():
         environment=environment,
         repeat_actions=1,
         cluster_spec=cluster_spec,
-        task_index=args.task_index
+        task_index=args.task_index,
+        save_path=args.logdir
     )
 
     report_episodes = args.episodes // 1000

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -33,7 +33,7 @@ from tensorforce import TensorForceError
 class Runner(object):
 
     # These agents can be used in an A3C fashion
-    async_supported = ('VPGAgent', 'PPOAgent')  # And potentially TRPOAgent, needs to be checked...
+    async_supported = ('DQNNstepAgent', 'VPGAgent', 'PPOAgent')  # And potentially TRPOAgent, needs to be checked...
 
     def __init__(self, agent, environment, repeat_actions=1, cluster_spec=None, task_index=None, save_path=None, save_episodes=None):
         """

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -102,20 +102,19 @@ class Runner(object):
             config = tf.ConfigProto(device_filters=['/job:ps', '/job:worker/task:{}/cpu:0'.format(self.task_index)])
 
             init_op = tf.global_variables_initializer()
+            logdir = self.save_path if self.save_path is not None else '/tmp/train_logs/'
             supervisor = tf.train.Supervisor(
                 is_chief=(self.task_index == 0),
-                logdir='/tmp/train_logs',
+                logdir=logdir,
                 global_step=self.agent.model.global_timestep,
                 init_op=tf.variables_initializer(self.agent.model.global_variables),
                 local_init_op=tf.variables_initializer(self.agent.model.variables),
                 init_fn=(lambda session: session.run(init_op)),
                 saver=self.agent.model.saver)
-            # summary_op=tf.summary.merge_all(),
-            # summary_writer=worker_agent.model.summary_writer)
 
             managed_session = supervisor.managed_session(server.target, config=config)
             session = managed_session.__enter__()
-            self.agent.model.set_session(session)
+            self.agent.model.set_session(session, supervisor)
             # session.run(self.agent.model.update_local)
 
         # save episode reward and length for statistics

--- a/tensorforce/models/dqn_nstep_model.py
+++ b/tensorforce/models/dqn_nstep_model.py
@@ -75,4 +75,12 @@ class DQNNstepModel(DQNModel):
         feed_dict.update({action: batch['actions'][name][:-1] for name, action in self.action.items()})
         feed_dict.update({internal: batch['internals'][n][:-1] for n, internal in enumerate(self.internal_inputs)})
         feed_dict.update({self.nstep_rewards[name]: nstep_rewards[name] for name, reward in nstep_rewards.items()})
+
+        # pass in terminals so that the global episode counter is correct in distributed mode
+        if self.distributed:
+            feed_dict.update({self.terminal: batch['terminals']})
         return feed_dict
+
+    def get_global_increment_value(self):
+        # nstep DQN doesn't pass in reward so use actions shape
+        return tf.shape(self.action[list(self.action.keys())[0]])[0]

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -125,7 +125,7 @@ class Model(object):
                     self.optimize = tf.group(
                         self.optimizer.apply_gradients(grads_and_vars=global_gradients),
                         self.update_local,
-                        self.global_timestep.assign_add(tf.shape(self.reward)[0]))
+                        self.global_timestep.assign_add(self.get_global_increment_value()))
                     self.increment_global_episode = self.global_episode.assign_add(tf.count_nonzero(input_tensor=self.terminal, dtype=tf.int32))
                 else:
                     self.loss = tf.losses.get_total_loss()
@@ -323,7 +323,6 @@ class Model(object):
         else:
             self.saver.save(self.session, path)
 
-
     def should_write_summaries(self, num_updates):
         return self.writer is not None and self.timestep > self.last_summary_step + self.summary_interval
 
@@ -334,3 +333,9 @@ class Model(object):
         if self.writer is not None:
             reward_summary = self.session.run(self.episode_reward_summary, feed_dict={self.tf_episode_reward: episode_reward})
             self.writer.add_summary(reward_summary, global_step=self.timestep)
+
+    def get_global_increment_value(self):
+        """
+            The amount to increment the global timestep. Should be a constant or tensorflow value
+        """
+        return tf.shape(self.reward)[0]

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -111,11 +111,11 @@ class QModel(Model):
                 self.global_last_target_update = tf.get_variable(name='last-target-update', dtype=tf.int32, initializer=0, trainable=False)
 
                 # check if timestep greater than last update + interval
-                self.global_should_update_target = self.global_timestep >= self.global_last_target_update
+                self.global_should_update_target = self.global_timestep >= self.global_last_target_update + self.target_update_frequency
 
                 def update_global_target():
                     # since this op automatically is run once on tf.cond init the target values will be the same as training at the start
-                    global_target_counter_update = tf.assign_add(self.global_last_target_update, self.target_update_frequency)
+                    global_target_counter_update = tf.assign(self.global_last_target_update, self.global_timestep)
                     # these update ops must be created here otherwise they will be run everytime
                     # https://github.com/tensorflow/tensorflow/issues/3287
                     target_network_update = self.create_target_update_operations(config)

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -96,11 +96,12 @@ class QModel(Model):
             tf.losses.add_loss(self.q_loss)
 
         # for each loss over an action create a summary
-        if len(self.q_loss.shape) > 1:
-            for action_ind in range(self.q_loss.shape[1]):
-                tf.summary.scalar('q-loss-action-{}'.format(action_ind), self.q_loss[action_ind])
-        else:
-            tf.summary.scalar('q-loss', self.q_loss)
+        if config.tf_summary_level >= 0:
+            if len(self.q_loss.shape) > 1:
+                for action_ind in range(self.q_loss.shape[1]):
+                    tf.summary.scalar('q-loss-action-{}'.format(action_ind), self.q_loss[action_ind])
+            else:
+                tf.summary.scalar('q-loss', self.q_loss)
 
         # Update target network
         with tf.name_scope('update-target'):


### PR DESCRIPTION
This changes update distributed to support tensorflow summaries, fixes some important issues,  and allows q_model target networks to be updated in distributed mode.

## Tensorflow Summaries
The "chief" agent (task index 0) will now output summaries in distributed mode. I had to add a supervisor argument into the set_session method on model.py because summaries can only be written through the supervisor in distributed mode. I've modified the distributed example to remove summaries from all workers except task 0.

## Distributed Fixes

1. Global shared optimizer, according to the A3C paper using a shared optimizer produces better results than each worker having it's own. This might make workers like 0.001% and save some memory since they don't have to calculate the optimizer update or store the params just the gradients.
2. Updating local vars. Fixed local vars were being updated from a cached copy of the global variables. Specifically, var.read_value() must be used to ensure tensorflow doesn't used the cached copy. Additionally, local vars are only updated after the gradient calculation. Reset now causes a copy from global -> local, this fixes problems where workers that start slowly had really old parameters. Or if a worker needs to be restarted it will copy from global first.
3. Added general helper methods that allow models to override how the global_timestep is incremented. This allows say DQN to only increment the timestep once even if batch size is 32. 

## Q Model target
Was able to get a tensorflow conditional statement that determines if the global model needs to update the target network. This was the major issue preventing distributed running of DQN & variants. So now all DQN methods should work in a distributed fashion.

I've tested Nstep DQN with these changes and it's now capable of running for an epoch or two before gradient explosion (up from about 10k steps to 1.2mil). I think that this is just a hyperparameter issue and that the distributed code is now correct (NStep DQN still doesn't clip gradients like the original paper so one bad update can mess up the whole thing). 

The policy gradient tests are failing because they don't have optimizers? If that's expected behavior then I can remove the check from the code.