### PR TITLE
max of 1 to max of epsilon

### DIFF
--- a/tensorforce/core/explorations/epsilon_anneal.py
+++ b/tensorforce/core/explorations/epsilon_anneal.py
@@ -33,7 +33,7 @@ class EpsilonAnneal(Exploration):
 
         offset = self.start_after
 
-        self.epsilon = min(1.0, max(
+        self.epsilon = min(self.epsilon, max(
             self.epsilon_final,
             1.0 - (timestep - offset) / (self.epsilon_timesteps - offset)
         ))


### PR DESCRIPTION
This was using a max of one which led to funny behaviour where it didn't use epsilon [see plot here](https://gist.github.com/wassname/21b0e3c5a7cf97a32d424cd851507fc3). This fixes it.