### PR TITLE
change half_life of 1 to epsilon_timesteps/10

### DIFF
--- a/tensorforce/core/explorations/epsilon_decay.py
+++ b/tensorforce/core/explorations/epsilon_decay.py
@@ -22,11 +22,12 @@ class EpsilonDecay(Exploration):
     difference between current and final epsilon to total timesteps.
     """
 
-    def __init__(self, epsilon=1.0, epsilon_final=0.1, epsilon_timesteps=10000, start_after=0):
+    def __init__(self, epsilon=1.0, epsilon_final=0.1, epsilon_timesteps=10000, start_after=0, half_lives=10):
         self.epsilon = epsilon
         self.epsilon_final = epsilon_final
         self.epsilon_timesteps = epsilon_timesteps
         self.start_after = start_after
+        self.half_life = self.epsilon_timesteps / half_lives
 
     def __call__(self, episode=0, timestep=0):
         if timestep < self.start_after:
@@ -35,8 +36,10 @@ class EpsilonDecay(Exploration):
         offset = self.start_after
 
         if timestep > self.epsilon_timesteps:
-            self.epsilon = self.epsilon_final
+            epsilon = self.epsilon_final
         else:
-            self.epsilon -= ((self.epsilon - self.epsilon_final) / self.epsilon_timesteps) * (timestep - offset)
+            epsilon = self.epsilon_final + \
+                (self.epsilon - self.epsilon_final) * \
+                2 ** (- (timestep - offset) / self.half_life)
 
-        return self.epsilon
+        return epsilon


### PR DESCRIPTION
If you plot this is has a half life of 1, independent of epsilon_timesteps. If you plot it you see exploration drop to epsilon_final in ~20 steps. 

This changes it to have a configurable amount of half lives per epsilon_timesteps. [Plots of before and after here](https://gist.github.com/wassname/21b0e3c5a7cf97a32d424cd851507fc3)