### PR TITLE
Make PPOAgent a MemoryAgent

### DIFF
--- a/examples/configs/ppo_cartpole.json
+++ b/examples/configs/ppo_cartpole.json
@@ -1,15 +1,17 @@
 {
   "log_level": "info",
-
+  "memory": {"type":"prioritized_replay"},
+  "update_frequency":256,
+  "first_update":512,
   "batch_size": 4000,
   "discount": 0.99,
   "gae_rewards": false,
   "gae_lambda": 0.97,
-  "normalize_advantage" : false,
+  "normalize_rewards" : false,
   "learning_rate" : 0.001,
   "entropy_penalty" :  0.01,
   "epochs" : 5,
-  "optimizer_batch_size" : 512,
+  "optimizer_batch_size" : 64,
   "loss_clipping" : 0.2,
 
   "baseline": {

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -28,39 +28,37 @@ from tensorforce.contrib.openai_gym import OpenAIGym
 # Create an OpenAIgym environment
 env = OpenAIGym('CartPole-v0')
 
-# Create a Trust Region Policy Optimization agent
+# Create a Proximal Policy Optimization agent
 agent = PPOAgent(
     Configuration(
-    log_level='info',
-    batch_size=4000,
+        log_level='info',
+        batch_size=256,
 
-    # max_kl_divergence=0.1,
-    # cg_iterations=20,
-    # cg_damping=0.001,
-    # ls_max_backtracks=10,
-    # ls_accept_ratio=0.9,
-    # ls_override=False,
+        memory=dict(
+            type='prioritized_replay',
+        ),
+        update_frequency=256,
+        first_update=512,
 
-    learning_rate=0.001,
-    entropy_penalty=0.01,
-    epochs=5,
-    optimizer_batch_size=512,
-    loss_clipping=0.2,
-    normalize_advantage=False,
-    baseline=dict(
-        type="mlp",
-        sizes=[32, 32],
-        epochs=1,
-        update_batch_size=512,
-        learning_rate=0.01
-    ),
-    states=env.states,
-    actions=env.actions,
-    network=layered_network_builder([
-        dict(type='dense', size=32, activation='tanh'),
-        dict(type='dense', size=32, activation='tanh')
-    ])
-))
+        learning_rate=0.0001,
+        optimizer_batch_size=64,
+        normalize_rewards=False,
+        gae_rewards=False,
+        baseline=dict(
+            type="mlp",
+            sizes=[32, 32],
+            epochs=1,
+            update_batch_size=64,
+            learning_rate=0.001
+        ),
+        states=env.states,
+        actions=env.actions,
+        network=layered_network_builder([
+            dict(type='dense', size=32, activation='tanh'),
+            dict(type='dense', size=32, activation='tanh')
+        ])
+    )
+)
 
 # Create the runner
 runner = Runner(agent=agent, environment=env)

--- a/tensorforce/agents/ppo_agent.py
+++ b/tensorforce/agents/ppo_agent.py
@@ -21,11 +21,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorforce.agents import BatchAgent
+from tensorforce.agents import MemoryAgent
 from tensorforce.models.ppo_model import PPOModel
 
-
-class PPOAgent(BatchAgent):
+class PPOAgent(MemoryAgent):
     """
     Proximal Policy Optimization agent ([Schulman et al., 2017]
     (https://openai-public.s3-us-west-2.amazonaws.com/blog/2017-07/ppo/ppo-arxiv.pdf).
@@ -39,10 +38,26 @@ class PPOAgent(BatchAgent):
     * `preprocessing`: dict or list containing state preprocessing configuration.
     * `exploration`: dict containing action exploration configuration.
 
-    The `BatchAgent` class additionally requires the following parameters:
-
+    The `MemoryAgent` class additionally requires the following parameters:
     * `batch_size`: integer of the batch size.
-    * `keep_last`: bool optionally keep the last observation for use in the next batch
+    * `memory_capacity`: integer of maximum experiences to store.
+    * `memory`: string indicating memory type ('replay' or 'prioritized_replay').
+    * `update_frequency`: integer indicating the number of steps between model updates.
+    * `first_update`: integer indicating the number of steps to pass before the first update.
+    * `repeat_update`: integer indicating how often to repeat the model update.
+
+    Each model requires the following configuration parameters:
+    * `discount`: float of discount factor (gamma).
+    * `learning_rate`: float of learning rate (alpha).
+    * `optimizer`: string of optimizer to use (e.g. 'adam').
+    * `device`: string of tensorflow device name.
+    * `tf_summary`: string directory to write tensorflow summaries. Default None
+    * `tf_summary_level`: int indicating which tensorflow summaries to create.
+    * `tf_summary_interval`: int number of calls to get_action until writing tensorflow summaries on update.
+    * `log_level`: string containing loglevel (e.g. 'info').
+    * `distributed`: boolean indicating whether to use distributed tensorflow.
+    * `global_model`: global model.
+    * `session`: session to use.
 
     A Policy Gradient Model expects the following additional configuration parameters:
 
@@ -53,14 +68,27 @@ class PPOAgent(BatchAgent):
     * `gae_lambda`: GAE lambda.
     * `normalize_rewards`: boolean indicating whether to normalize rewards.
 
+    The PPO agent expects the following additional configuration parameters:
 
-    The TRPO agent expects the following additional configuration parameters:
-
-    * `learning_rate`: float of learning rate (alpha).
-    * `optimizer`: string of optimizer to use (e.g. 'adam').
-
+    * `entropy_penalty`: float (e.g. 0.01)
+    * `loss_clipping`: float trust region clipping (e.g. 0.2)
+    * `epochs`: int number of training epochs for optimizer (e.g. 10)
+    * `optimizer_batch_size`: int batch size for optimizer (e.g. 64)
 
     """
 
     name = 'PPOAgent'
     model = PPOModel
+
+    default_config = dict(
+        batch_size=128,
+        memory=dict(
+            type='prioritized_replay',
+        ),
+        update_frequency=128,
+        first_update=256,
+    )
+
+    def __init__(self, config, model=None):
+        config.default(PPOAgent.default_config)
+        super(PPOAgent, self).__init__(config, model)

--- a/tensorforce/tests/test_ppo_agent.py
+++ b/tensorforce/tests/test_ppo_agent.py
@@ -37,6 +37,8 @@ class TestPPOAgent(unittest.TestCase):
             environment = MinimalTest(definition=False)
             config = Configuration(
                 batch_size=20,
+                first_update=80,
+                update_frequency=20,
                 entropy_penalty=0.01,
                 loss_clipping=0.1,
                 epochs=10,
@@ -72,6 +74,8 @@ class TestPPOAgent(unittest.TestCase):
             environment = MinimalTest(definition=True)
             config = Configuration(
                 batch_size=20,
+                first_update=80,
+                update_frequency=20,
                 entropy_penalty=0.01,
                 loss_clipping=0.1,
                 epochs=10,
@@ -114,6 +118,8 @@ class TestPPOAgent(unittest.TestCase):
             environment = MinimalTest(definition=[False, (False, 2), (True, 2)])
             config = Configuration(
                 batch_size=20,
+                first_update=80,
+                update_frequency=20,
                 entropy_penalty=0.01,
                 loss_clipping=0.1,
                 epochs=10,
@@ -154,6 +160,8 @@ class TestPPOAgent(unittest.TestCase):
                 epochs=10,
                 optimizer_batch_size=10,
                 learning_rate=0.0005,
+                first_update=80,
+                update_frequency=20,
                 states=environment.states,
                 actions=actions,
                 network=layered_network_builder([
@@ -175,4 +183,3 @@ class TestPPOAgent(unittest.TestCase):
 
         print('PPO agent (beta) passed = {}'.format(passed))
         self.assertTrue(passed >= 4)
-

--- a/tensorforce/tests/test_quickstart_example.py
+++ b/tensorforce/tests/test_quickstart_example.py
@@ -41,14 +41,25 @@ class TestQuickstartExample(unittest.TestCase):
             # Create a Trust Region Policy Optimization agent
             agent = PPOAgent(config=Configuration(
                 log_level='info',
-                batch_size=4096,
+                batch_size=256,
 
-                gae_lambda=0.97,
-                learning_rate=0.001,
-                entropy_penalty=0.01,
-                epochs=5,
-                optimizer_batch_size=512,
-                loss_clipping=0.2,
+                memory=dict(
+                    type='prioritized_replay',
+                ),
+                update_frequency=256,
+                first_update=512,
+
+                learning_rate=0.0001,
+                optimizer_batch_size=64,
+                normalize_rewards=False,
+                gae_rewards=False,
+                baseline=dict(
+                    type="mlp",
+                    sizes=[32, 32],
+                    epochs=1,
+                    update_batch_size=64,
+                    learning_rate=0.001
+                ),
                 states=env.states,
                 actions=env.actions,
                 network=layered_network_builder([


### PR DESCRIPTION
This change lets PPO use prioritised replay memory which makes it
converge faster on cartpolev0.

However, it converges much slower when using replay memory. I made the
default as prioritized_replay but do we want this change?
@michaelschaarschmidt added PPO so it would be good to get his thoughts
and a code review.

The changes also fixes minor things like the docstring and returning losses for
each instance. As well as updates corresponding tests, config, and
examples.