### PR TITLE
SummarySessionWrapper to reduce Tensorboard tf.summary logging overhead

### DIFF
--- a/tensorforce/config.py
+++ b/tensorforce/config.py
@@ -107,7 +107,7 @@ class Configuration(object):
         return self._config.keys()
 
     def copy(self):
-        return Configuration(**self._config)
+        return Configuration(allow_defaults=self.allow_defaults, **self._config)
 
     def as_dict(self):
         d = dict()

--- a/tensorforce/core/networks/layers.py
+++ b/tensorforce/core/networks/layers.py
@@ -174,7 +174,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0, l1_regulariz
             tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=weights))
         if l1_regularization > 0.0:
             weight_l1_t = tf.convert_to_tensor(l1_regularization, dtype=tf.float32, name='weight_l1')
-            tf.losses.add_loss(tf.multiply(weight_l1_t, tf.reduce_sum(tf.abs(weights)), name='loss_l1_weights'))
+            tf.losses.add_loss(tf.multiply(weight_l1_t, tf.reduce_sum(tf.abs(weights))))
         else:
             weight_l1_t = None
 
@@ -189,7 +189,7 @@ def linear(x, size, weights=None, bias=True, l2_regularization=0.0, l1_regulariz
             if l2_regularization > 0.0:
                 tf.losses.add_loss(l2_regularization * tf.nn.l2_loss(t=bias))
             if l1_regularization > 0.0:
-                tf.losses.add_loss(tf.multiply(weight_l1_t, tf.reduce_sum(tf.abs(bias)), name='loss_l1_bias'))
+                tf.losses.add_loss(tf.multiply(weight_l1_t, tf.reduce_sum(tf.abs(bias))))
 
             x = tf.nn.bias_add(value=x, bias=bias)
 

--- a/tensorforce/util.py
+++ b/tensorforce/util.py
@@ -215,8 +215,11 @@ class SummarySessionWrapper(object):
             return self._returns
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if not self._have_executed:
-            raise TensorForceError('{} exiting without run() being called.'.format(self.__class__.__name__))
-        if self._should_write_summaries:
-            self._model.write_summaries(self._returns[-1])
-            self._model.last_summary_step = self._model.timestep
+        if exc_tb is None:
+            if not self._have_executed:
+                raise TensorForceError('{} exiting without run() being called.'.format(self.__class__.__name__))
+            if self._should_write_summaries:
+                self._model.write_summaries(self._returns[-1])
+                self._model.last_summary_step = self._model.timestep
+        else:
+            return 0


### PR DESCRIPTION
The previous workflow for Tensorboard logging was:

1. Check if the model should log
2. If so, append the summaries to fetches
3. Call session.run()
4. If should log, grab the summary results from session.run(), log them, and update the last log step.

SummarySessionWrapper makes this all transparent to the user with a simple interface:

`
with SummarySessionWrapper(self, fetches, feed_dict) as session:
    returns = session.run()
`

Behind the scenes, it checks to see if the model should log, and if so, tags on model.tf_summaries, which are set up when the instance is created.  when SummarySessionWrapper.run() is called, it only returns the original fetches, and hangs on to the tf_summaries for itself.  They are written on `__exit__`, and the last logged index is updated.  

This is also a step in the right direction for #146.

This has been implemented for the Model base class and PPOModel.  I can get to others upon request, otherwise will as I spend more time with them.