### PR TITLE
Fix  'observation' referenced before assignment"

### DIFF
--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -90,7 +90,7 @@ class PrioritizedReplay(Memory):
                 index = randrange(self.none_priority_index)
                 while index in self.batch_indices:
                     index = randrange(self.none_priority_index)
-                observation = self.observations[index]
+                _, observation = self.observations[index]
             else:
                 while True:
                     sample = random()

--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -90,6 +90,7 @@ class PrioritizedReplay(Memory):
                 index = randrange(self.none_priority_index)
                 while index in self.batch_indices:
                     index = randrange(self.none_priority_index)
+                observation = self.observations[index]
             else:
                 while True:
                     sample = random()


### PR DESCRIPTION
If prioritized_replay enters the loop in line 89, it gets the index but not the observation, leading to the error "UnboundLocalError: local variable 'observation' referenced before assignment". This fixes it.