### PR TITLE
error instead of infinite loop

### DIFF
--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -69,6 +69,8 @@ class PrioritizedReplay(Memory):
         Returns: A dict containing states, actions, rewards, terminals, internal states (and next states)
 
         """
+        if batch_size<len(self.observations):
+            raise TensorForceError("Batch size is larger than observations in memory: increase config.first_update.")
         states = {name: np.zeros((batch_size,) + tuple(state.shape), dtype=util.np_dtype(state.type)) for name, state in self.states_config.items()}
         actions = {name: np.zeros((batch_size,) + tuple(action.shape), dtype=util.np_dtype('float' if action.continuous else 'int')) for name, action in self.actions_config.items()}
         rewards = np.zeros((batch_size,), dtype=util.np_dtype('float'))

--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -69,7 +69,7 @@ class PrioritizedReplay(Memory):
         Returns: A dict containing states, actions, rewards, terminals, internal states (and next states)
 
         """
-        if batch_size<len(self.observations):
+        if batch_size>len(self.observations):
             raise TensorForceError("Batch size is larger than observations in memory: increase config.first_update.")
         states = {name: np.zeros((batch_size,) + tuple(state.shape), dtype=util.np_dtype(state.type)) for name, state in self.states_config.items()}
         actions = {name: np.zeros((batch_size,) + tuple(action.shape), dtype=util.np_dtype('float' if action.continuous else 'int')) for name, action in self.actions_config.items()}


### PR DESCRIPTION
If the first update is smaller than the batch size them prioritized_replay can go into an infinite loop on lines 93 and 98, this will raise an informative error instead.