### PR TITLE
Warning when get_batch can be very slow

### DIFF
--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -42,7 +42,6 @@ class PrioritizedReplay(Memory):
         self.last_observation = None  # stores last observation until next_state value is known
         
         self.logger = logging.getLogger(__name__)
-        self.logger.setLevel(util.log_levels[config.log_level])
 
     def add_observation(self, state, action, reward, terminal, internal):
         if self.internals_config is None and internal is not None:

--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -39,6 +39,9 @@ class PrioritizedReplay(Memory):
         self.none_priority_index = 0
         self.batch_indices = None
         self.last_observation = None  # stores last observation until next_state value is known
+        
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(util.log_levels[config.log_level])
 
     def add_observation(self, state, action, reward, terminal, internal):
         if self.internals_config is None and internal is not None:
@@ -92,6 +95,8 @@ class PrioritizedReplay(Memory):
                     index = randrange(self.none_priority_index)
             else:
                 while True:
+                    if len(self.observations) < batch_size*100:
+                        self.logger.warn("batch size should be much smaller than the number of observations in memory or get_batch wil be extremely slow. Increase config.first_update")
                     sample = random()
                     for index, (priority, observation) in enumerate(self.observations):
                         sample -= priority / sum_priorities

--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -24,6 +24,7 @@ from __future__ import division
 from random import random, randrange
 from six.moves import xrange
 import numpy as np
+import logging
 
 from tensorforce import util, TensorForceError
 from tensorforce.core.memories import Memory

--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -94,9 +94,9 @@ class PrioritizedReplay(Memory):
                 while index in self.batch_indices:
                     index = randrange(self.none_priority_index)
             else:
+                if len(self.observations) < batch_size*100:
+                    self.logger.warn("batch size should be much smaller than the number of observations in memory or get_batch wil be extremely slow. Increase config.first_update")
                 while True:
-                    if len(self.observations) < batch_size*100:
-                        self.logger.warn("batch size should be much smaller than the number of observations in memory or get_batch wil be extremely slow. Increase config.first_update")
                     sample = random()
                     for index, (priority, observation) in enumerate(self.observations):
                         sample -= priority / sum_priorities


### PR DESCRIPTION
When entering loop 97, if len(observations) is not much larger than batch, it is extremely slow (minutes), due to the way the algorithm works. This was very confusing to me so I thought it might be valuable to add a warning, although I'm not sure if it's needed and I'm not sure if this is the best way. Happy to go with what you think.

This can wait until the optimiser update, cheers.;