### PR TITLE
linear search with numpy 10x faster

### DIFF
--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -106,9 +106,9 @@ class PrioritizedReplay(Memory):
             if sum_priorities / self.capacity < util.epsilon:
                 p = None
             else:
-                probabilities = priorities / sum_priorities
-                unsampled_probabilities = probabilities[unsampled_indices]
-                p = unsampled_probabilities / unsampled_probabilities.sum()
+                unsampled_probabilities = priorities[unsampled_indices]
+                p = unsampled_probabilities - unsampled_probabilities.min()
+                p /= p.sum()
             self.batch_indices += np.random.choice(unsampled_indices, size=batch_size - len(
                 self.batch_indices), replace=False, p=p).tolist()
 


### PR DESCRIPTION
I tried doing the linear search using numpy and the results are 10x faster with slightly better scaling. This could be used until someone does a tensorflow implementation or a better search algorithm.

Feel free to leave it until you guys have time.

|number of memory observations|old speed (ms)|numpy (ms)|
|-|-|-|
|1e3|13.9 |0.9|
|1e4|132.0 |4.7| 
|1e5|1690.0 |55.6| 

Related discussion: https://github.com/reinforceio/tensorforce/pull/164#issuecomment-336389944