### PR TITLE
missing Exploration.from_config

### DIFF
--- a/tensorforce/core/explorations/exploration.py
+++ b/tensorforce/core/explorations/exploration.py
@@ -29,7 +29,18 @@ class Exploration(object):
         """
         exploration = util.get_object(
             obj=spec,
-            predefined=tensorforce.core.explorations.explorations
+            predefined_objects=tensorforce.core.explorations.explorations
         )
         assert isinstance(exploration, Exploration)
         return exploration
+
+    @staticmethod
+    def from_config(config, kwargs=None):
+        """
+        Creates an exploration object from a specification dict.
+        """
+        return util.get_object(
+            obj=config,
+            predefined_objects=tensorforce.core.explorations.explorations,
+            kwargs=kwargs
+        )


### PR DESCRIPTION
As w/ all my newbie PRs, feel free to scrap mine & use your own if y'all have a correct solution. Defining exploration in the config gave "Exploration doesn't have from_config()" (ish).