### PR TITLE
Add Dropout layer, Lstm dropout handling, pass training placeholder during layer.apply()

### DIFF
--- a/tensorforce/core/baselines/network_baseline.py
+++ b/tensorforce/core/baselines/network_baseline.py
@@ -46,7 +46,7 @@ class NetworkBaseline(Baseline):
         super(NetworkBaseline, self).__init__(scope, summary_labels)
 
     def tf_predict(self, states):
-        embedding = self.network.apply(x=states)
+        embedding = self.network.apply(x=states, training=False)
         prediction = self.linear.apply(x=embedding)
         return tf.squeeze(input=prediction, axis=1)
 

--- a/tensorforce/core/networks/__init__.py
+++ b/tensorforce/core/networks/__init__.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 
-from tensorforce.core.networks.layer import Layer, Flatten, Nonlinearity, Linear, Dense, Dueling, Conv1d, Conv2d, Lstm
+from tensorforce.core.networks.layer import Layer, Flatten, Dropout, Nonlinearity, Linear, Dense, Dueling, Conv1d, Conv2d, Lstm
 from tensorforce.core.networks.network import Network, LayerBasedNetwork, LayeredNetwork
 
 
 layers = dict(
     flatten=Flatten,
+    dropout=Dropout,
     nonlinearity=Nonlinearity,
     linear=Linear,
     dense=Dense,
@@ -33,6 +34,7 @@ __all__ = [
     'layers',
     'Layer',
     'Flatten',
+    'Dropout',
     'Nonlinearity',
     'Linear',
     'Dense',

--- a/tensorforce/core/networks/network.py
+++ b/tensorforce/core/networks/network.py
@@ -62,7 +62,7 @@ class Network(object):
                 custom_getter_=custom_getter
             )
 
-    def tf_apply(self, x, internals=(), return_internals=False):
+    def tf_apply(self, x, internals=(), return_internals=False, training=None):
         """
         Creates the TensorFlow operations for applying the network to the given input.
 
@@ -70,6 +70,7 @@ class Network(object):
             x: Network input tensor or dict of input tensors
             internals: List of prior internal state tensors
             return_internals: If true, also returns posterior internal state tensors
+            training: Is currently training? `True` during update() `False` otherwise (eg. for Dropout)
 
         Returns:
             Network output tensor, plus optionally list of posterior internal state tensors
@@ -226,7 +227,7 @@ class LayeredNetwork(LayerBasedNetwork):
 
                 self.add_layer(layer=layer)
 
-    def tf_apply(self, x, internals=(), return_internals=False):
+    def tf_apply(self, x, internals=(), return_internals=False, training=None):
         if isinstance(x, dict):
             if len(x) != 1:
                 raise TensorForceError('Layered network must have only one input, but {} given.'.format(len(x)))
@@ -237,7 +238,7 @@ class LayeredNetwork(LayerBasedNetwork):
         for layer in self.layers:
             layer_internals = [internals[index + n] for n in range(layer.num_internals)]
             index += layer.num_internals
-            x = layer.apply(x, *layer_internals)
+            x = layer.apply(x, *layer_internals, training=training)
 
             if not isinstance(x, tf.Tensor):
                 internal_outputs.extend(x[1])

--- a/tensorforce/models/distribution_model.py
+++ b/tensorforce/models/distribution_model.py
@@ -113,7 +113,7 @@ class DistributionModel(Model):
         )
 
     def tf_actions_and_internals(self, states, internals, deterministic):
-        embedding, internals = self.network.apply(x=states, internals=internals, return_internals=True)
+        embedding, internals = self.network.apply(x=states, internals=internals, return_internals=True, training=self.training)
         actions = dict()
         for name, distribution in self.distributions.items():
             distr_params = distribution.parameterize(x=embedding)
@@ -121,7 +121,7 @@ class DistributionModel(Model):
         return actions, internals
 
     def tf_kl_divergence(self, states, internals):
-        embedding = self.network.apply(x=states, internals=internals)
+        embedding = self.network.apply(x=states, internals=internals, training=self.training)
         kl_divergences = list()
 
         for name, distribution in self.distributions.items():
@@ -163,7 +163,7 @@ class DistributionModel(Model):
 
         if self.entropy_regularization is not None and self.entropy_regularization > 0.0:
             entropies = list()
-            embedding = self.network.apply(x=states, internals=internals)
+            embedding = self.network.apply(x=states, internals=internals, training=self.training)
             for name, distribution in self.distributions.items():
                 distr_params = distribution.parameterize(x=embedding)
                 entropy = distribution.entropy(distr_params=distr_params)

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -460,6 +460,9 @@ class Model(object):
         # Update flag
         self.update_input = tf.placeholder(dtype=tf.bool, shape=(), name='update')
 
+        # Is-training flag
+        self.training = tf.placeholder_with_default(False, shape=(), name='is-training')
+
         # TensorFlow functions
         self.fn_discounted_cumulative_reward = tf.make_template(
             name_='discounted-cumulative-reward',
@@ -868,6 +871,7 @@ class Model(object):
             )
             feed_dict[self.terminal_input] = (terminal,)
             feed_dict[self.reward_input] = (reward,)
+            feed_dict[self.training] = True
 
         feed_dict[self.deterministic_input] = True
         feed_dict[self.update_input] = True

--- a/tensorforce/models/pg_log_prob_model.py
+++ b/tensorforce/models/pg_log_prob_model.py
@@ -29,7 +29,7 @@ class PGLogProbModel(PGModel):
     """
 
     def tf_pg_loss_per_instance(self, states, internals, actions, terminal, reward):
-        embedding = self.network.apply(x=states, internals=internals)
+        embedding = self.network.apply(x=states, internals=internals, training=self.training)
         log_probs = list()
 
         for name, distribution in self.distributions.items():

--- a/tensorforce/models/pg_model.py
+++ b/tensorforce/models/pg_model.py
@@ -122,7 +122,7 @@ class PGModel(DistributionModel):
                 state_value = self.baseline.predict(states=states)
 
             elif self.baseline_mode == 'network':
-                embedding = self.network.apply(x=states, internals=internals)
+                embedding = self.network.apply(x=states, internals=internals, training=self.training)
                 state_value = self.baseline.predict(states=embedding)
 
             if self.gae_lambda is None:
@@ -186,7 +186,7 @@ class PGModel(DistributionModel):
 
         elif self.baseline_mode == 'network':
             def fn_loss():
-                loss = self.baseline.loss(states=self.network.apply(x=states, internals=internals), reward=reward)
+                loss = self.baseline.loss(states=self.network.apply(x=states, internals=internals, training=self.training), reward=reward)
                 regularization_loss = self.baseline.regularization_loss()
                 if regularization_loss is None:
                     return loss

--- a/tensorforce/models/pg_prob_ratio_model.py
+++ b/tensorforce/models/pg_prob_ratio_model.py
@@ -56,7 +56,7 @@ class PGProbRatioModel(PGModel):
         )
 
     def tf_pg_loss_per_instance(self, states, internals, actions, terminal, reward):
-        embedding = self.network.apply(x=states, internals=internals)
+        embedding = self.network.apply(x=states, internals=internals, training=self.training)
         prob_ratios = list()
         for name, distribution in self.distributions.items():
             distr_params = distribution.parameterize(x=embedding)
@@ -81,7 +81,7 @@ class PGProbRatioModel(PGModel):
             return -tf.minimum(x=(prob_ratio * reward), y=(clipped_prob_ratio * reward))
 
     def tf_reference(self, states, internals, actions):
-        embedding = self.network.apply(x=states, internals=internals)
+        embedding = self.network.apply(x=states, internals=internals, training=self.training)
         log_probs = list()
         for name in sorted(self.distributions):
             distribution = self.distributions[name]
@@ -99,7 +99,7 @@ class PGProbRatioModel(PGModel):
             terminal=terminal,
             reward=reward
         )
-        embedding = self.network.apply(x=states, internals=internals)
+        embedding = self.network.apply(x=states, internals=internals, training=self.training)
         log_probs = list()
         for name in sorted(self.distributions):
             distribution = self.distributions[name]

--- a/tensorforce/models/q_demo_model.py
+++ b/tensorforce/models/q_demo_model.py
@@ -76,7 +76,7 @@ class QDemoModel(QModel):
         )
 
     def tf_demo_loss(self, states, actions, terminal, reward, internals):
-        embedding = self.network.apply(x=states, internals=internals)
+        embedding = self.network.apply(x=states, internals=internals, training=self.training)
         deltas = list()
 
         for name, distribution in self.distributions.items():

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -84,13 +84,15 @@ class QModel(DistributionModel):
     def tf_loss_per_instance(self, states, internals, actions, terminal, reward):
         embedding = self.network.apply(
             x={name: state[:-1] for name, state in states.items()},
-            internals=[internal[:-1] for internal in internals])
+            internals=[internal[:-1] for internal in internals],
+            training=self.training)
 
         # Both networks can use the same internals, could that be a problem?
         # Otherwise need to handle internals indices correctly everywhere
         target_embedding = self.target_network.apply(
             x={name: state[1:] for name, state in states.items()},
-            internals=[internal[1:] for internal in internals]
+            internals=[internal[1:] for internal in internals],
+            training=self.training
         )
 
         deltas = list()


### PR DESCRIPTION
Attempt#1 for handling dropout. Background as I know it: dropout should be applied as an additional layer (1) after the input layer, (2) after any dense layers. For Lstm layers, dropout is handled internally by TensorFlow w/ a different mechanic, so should be passed as an argument (as it currently is). AFAIK you don't use dropout w/ Conv2d ([to investigate](https://www.reddit.com/r/MachineLearning/comments/42nnpe/why_do_i_never_see_dropout_applied_in/)). So an example: `[{type: 'dropout', rate: .5}, {type: 'lstm', dropout=.5, ...}, {type: 'dense', ...}, {type: 'dropout', rate: .5}]`

The dropout layers (`tf.layers.dropout` & `tf.contrib.rnn.DropoutWrapper`) take a `training` `tf.placeholder` argument. Usually `tf.placeholder_with_default(False, ...)` so we're forced to explicitly activate it during training (that is, during `model.update()`). 

This was simpler in #master (sloppy commit https://github.com/lefnire/tensorforce/commit/4c0224ca719cc8e827029f0ccca6b41846f16187). It's tougher here; as you can see I'm passing the `training` arg to every `network.apply` => `layer.tf_apply`, which results in scattering this arg all over the place. It would be cleaner if `training` were passed to `__init__` functions, but the order in which model subclasses are calling parent `__init__` fns makes it difficult to so do (LMK if you want a detailed explanation of that). 

Anyway, worth chatting about - I expect this won't be merged as is :) 