### PR TITLE
Change Exploration.from_config calls to Exploration.from_spec

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -146,7 +146,7 @@ class Agent(object):
             if isinstance(action['shape'], int):  # Shape: int to unary tuple
                 action['shape'] = (action['shape'],)
             if config.exploration is not None:
-                self.exploration['action'] = Exploration.from_config(config=config.exploration)
+                self.exploration['action'] = Exploration.from_spec(config.exploration)
 
         else:  # Multi-action
             self.unique_action = False
@@ -163,7 +163,7 @@ class Agent(object):
                 if isinstance(action['shape'], int):  # Shape: int to unary tuple
                     action['shape'] = (action['shape'],)
                 if config.exploration is not None and name in config.exploration:
-                    self.exploration[name] = Exploration.from_config(config=config.exploration[name])
+                    self.exploration[name] = Exploration.from_spec(config.exploration[name])
 
         # reward preprocessing config
         if config.reward_preprocessing is None:


### PR DESCRIPTION
`Exploration.from_config` was removed in https://github.com/reinforceio/tensorforce/commit/1a28dbd61377e0d3b8b3a1c29195bf79837ab192 per https://github.com/reinforceio/tensorforce/pull/171, but it seems calls to that function haven't been replaced w/ `Exploration.from_spec`, resulting in:

```
(btc3) lefnire@lefnire-ubuntu:~/Sites/btc$ python tforce/single.py 
[2017-10-22 08:14:24,523] Making new env: BTC-v0
2017-10-22 08:14:24.602836: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:892] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2017-10-22 08:14:24.603044: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1030] Found device 0 with properties: 
name: GeForce GTX 1080 Ti major: 6 minor: 1 memoryClockRate(GHz): 1.582
pciBusID: 0000:01:00.0
totalMemory: 10.90GiB freeMemory: 2.73GiB
2017-10-22 08:14:24.603057: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX 1080 Ti, pci bus id: 0000:01:00.0, compute capability: 6.1)
Traceback (most recent call last):
  File "tforce/single.py", line 15, in <module>
    env_args=dict(is_main=True)
  File "/home/lefnire/Sites/btc/agent_conf.py", line 422, in conf
    agent=make_agent() if with_agent else make_agent,
  File "/home/lefnire/Sites/btc/agent_conf.py", line 418, in make_agent
    config=conf
  File "/home/lefnire/Sites/btc/tmp/tensorforce2/tensorforce/agents/ppo_agent.py", line 138, in __init__
    super(PPOAgent, self).__init__(states_spec, actions_spec, config)
  File "/home/lefnire/Sites/btc/tmp/tensorforce2/tensorforce/agents/batch_agent.py", line 52, in __init__
    super(BatchAgent, self).__init__(states_spec, actions_spec, config)
  File "/home/lefnire/Sites/btc/tmp/tensorforce2/tensorforce/agents/agent.py", line 149, in __init__
    self.exploration['action'] = Exploration.from_config(config=config.exploration)
AttributeError: type object 'Exploration' has no attribute 'from_config'
```