### PR TITLE
actions_spec is dict, dot-accessor => key-accessor

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -247,13 +247,13 @@ class Agent(object):
 
                 if self.actions_spec[name]['type'] == 'bool':
                     if random() < exploration(episode=self.episode, timestep=self.timestep):
-                        shape = self.actions_spec[name].shape
+                        shape = self.actions_spec[name]['shape']
                         self.current_actions[name] = (np.random.random_sample(size=shape) < 0.5)
 
                 elif self.actions_spec[name]['type'] == 'int':
                     if random() < exploration(episode=self.episode, timestep=self.timestep):
-                        shape = self.actions_spec[name].shape
-                        num_actions = self.actions_spec[name].num_actions
+                        shape = self.actions_spec[name]['shape']
+                        num_actions = self.actions_spec[name]['num_actions']
                         self.current_actions[name] = np.random.randint(low=num_actions, size=shape)
 
                 elif self.actions_spec[name]['type'] == 'float':


### PR DESCRIPTION
Might be just my setup, but just in case (feel free to close). I'm getting the following:

```
(btc3) lefnire@lefnire-ubuntu:~/Sites/btc$ python tforce/single.py 
[2017-10-22 08:18:00,634] Making new env: BTC-v0
2017-10-22 08:18:00.714209: I tensorflow/stream_executor/cuda/cuda_gpu_executor.cc:892] successful NUMA node read from SysFS had negative value (-1), but there must be at least one NUMA node, so returning NUMA node zero
2017-10-22 08:18:00.714420: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1030] Found device 0 with properties: 
name: GeForce GTX 1080 Ti major: 6 minor: 1 memoryClockRate(GHz): 1.582
pciBusID: 0000:01:00.0
totalMemory: 10.90GiB freeMemory: 2.75GiB
2017-10-22 08:18:00.714437: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX 1080 Ti, pci bus id: 0000:01:00.0, compute capability: 6.1)
2017-10-22 08:18:03.036617: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1120] Creating TensorFlow device (/device:GPU:0) -> (device: 0, name: GeForce GTX 1080 Ti, pci bus id: 0000:01:00.0, compute capability: 6.1)
WARNING:tensorflow:Standard services need a 'logdir' passed to the SessionManager
[2017-10-22 08:18:03,406] Standard services need a 'logdir' passed to the SessionManager
[2017-10-22 08:18:03,406] Configuration values not accessed: keep_last
ppo_agent_conv2|dropout:None
mode:  ALL  row_count:  376799  split:  301439
Traceback (most recent call last):
  File "tforce/single.py", line 19, in <module>
    runner.run()
  File "/home/lefnire/Sites/btc/tmp/tensorforce2/tensorforce/execution/runner.py", line 90, in run
    action, action_true = self.agent.act(states=state, deterministic=deterministic)
  File "/home/lefnire/Sites/btc/tmp/tensorforce2/tensorforce/agents/agent.py", line 256, in act
    shape = self.actions_spec[name].shape
AttributeError: 'dict' object has no attribute 'shape'
```

Note `self.actions_spec =` is explicitly cast as `dict` [in `__init__`](https://github.com/reinforceio/tensorforce/blob/master/tensorforce/agents/agent.py#L134). I may not have caught all cases of this.