### PR TITLE
Warn when setting `exploration` in ppo_agent config

### DIFF
--- a/tensorforce/agents/ppo_agent.py
+++ b/tensorforce/agents/ppo_agent.py
@@ -125,6 +125,9 @@ class PPOAgent(BatchAgent):
         # random_sampling=True  # Sampling strategy for replay memory
 
     def __init__(self, states_spec, actions_spec, network_spec, config):
+        if config['exploration']:
+            self.logger.warning("PPO implicitly explores via sampling (deterministic policy gradient), we recommend "
+                                "setting `exploration` to `None`")
         self.network_spec = network_spec
         config = config.copy()
         config.default(self.__class__.default_config)


### PR DESCRIPTION
For consideration re https://gitter.im/reinforceio/TensorForce?at=59f1ed7632e080696e2a8884. I've had my own set to `type=epsilon` this whole time. I had some suspicion about it, but couldn't see any special-handling in PPO in either 0.2 or 0.3 re: exploration, so moved on. LMK if I'm misunderstanding something