### PR TITLE
Update ppo_agent.json. json not valid

### DIFF
--- a/examples/configs/ppo_agent.json
+++ b/examples/configs/ppo_agent.json
@@ -14,5 +14,5 @@
 
     "baseline_mode": null,
     "baseline":  null,
-    "baseline_optimizer": null,
+    "baseline_optimizer": null
 }


### PR DESCRIPTION
Fixing a trailing comma error in the json specification for ppo_agent