### PR TITLE
Allows custom baseline network

### DIFF
--- a/tensorforce/core/baselines/__init__.py
+++ b/tensorforce/core/baselines/__init__.py
@@ -23,7 +23,8 @@ from tensorforce.core.baselines.cnn_baseline import CNNBaseline
 baselines = dict(
     aggregated=AggregatedBaseline,
     mlp=MLPBaseline,
-    cnn=CNNBaseline
+    cnn=CNNBaseline,
+    custom=NetworkBaseline
 )
 
 


### PR DESCRIPTION
Eh, "PR".. one-liner.. Re: https://github.com/reinforceio/tensorforce/issues/118#issuecomment-340088616. Handy for people using a custom-defined network, rather than `network_builder` ([example](https://github.com/reinforceio/tensorforce/blob/master/tensorforce/tests/test_tutorial_code.py#L226))