### PR TITLE
ThreadedRunner: swap terminal/reward order

### DIFF
--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -73,12 +73,12 @@ class ThreadedRunner(object):
                 if repeat_actions > 1:
                     reward = 0
                     for repeat in xrange(repeat_actions):
-                        state, step_reward, terminal = environment.execute(actions=action)
+                        state, terminal, step_reward = environment.execute(actions=action)
                         reward += step_reward
                         if terminal:
                             break
                 else:
-                    state, reward, terminal = environment.execute(actions=action)
+                    state, terminal, reward = environment.execute(actions=action)
 
                 agent.observe(reward=reward, terminal=terminal)
 


### PR DESCRIPTION
Comment from https://github.com/reinforceio/tensorforce/commit/e0dead7ce49935210074ec9d449990c18065f0d4#commitcomment-25330825

>So ThreadedRunner & Runner's reward/terminal order are different (https://github.com/reinforceio/tensorforce/blob/master/tensorforce/execution/runner.py#L95). _This_ here looks like the correct way, according to standard environments, but ThreadedRunner won't run for me where Runner will! I swapped them in this file to double check, and sure enough that fixes it. Something wonky in the Gym wrapper maybe?

>[edit] Ah, sure enough - Gym wrapper swaps them here https://github.com/reinforceio/tensorforce/blob/master/tensorforce/contrib/openai_gym.py#L65. Not sure the thinking on the swap, but it's pretty consistent throughout the codebase - so seems the fix for now is just swap them in ThreadedRunner. Will submit a PR

@michaelschaarschmidt mentioned:

>oh looks like i missed that line, didnt prevent it from running ale

I'm using a [gym-wrapped](https://github.com/reinforceio/tensorforce/blob/master/tensorforce/contrib/openai_gym.py) env, I wonder if indeed there are some general inconsistencies in reward/terminal order? I'll keep my eye out.