### PR TITLE
fix "object has no attribute 'weights'"

### DIFF
--- a/tensorforce/core/networks/layer.py
+++ b/tensorforce/core/networks/layer.py
@@ -245,7 +245,7 @@ class Linear(Layer):
             self.weights_init = tf.random_normal_initializer(mean=0.0, stddev=stddev, dtype=tf.float32)
 
         elif isinstance(self.weights_init, float):
-            if self.weights == 0.0:
+            if self.weights_init == 0.0:
                 self.weights_init = tf.zeros_initializer(dtype=tf.float32)
             else:
                 self.weights_init = tf.constant_initializer(value=self.weights, dtype=tf.float32)

--- a/tensorforce/core/networks/layer.py
+++ b/tensorforce/core/networks/layer.py
@@ -252,23 +252,23 @@ class Linear(Layer):
 
         elif isinstance(self.weights_init, list):
             self.weights_init = np.asarray(self.weights_init, dtype=np.float32)
-            if self.weights.shape != weights_shape:
+            if self.weights_init.shape != weights_shape:
                 raise TensorForceError(
-                    'Weights shape {} does not match expected shape {} '.format(self.weights.shape, weights_shape)
+                    'Weights shape {} does not match expected shape {} '.format(self.weights_init.shape, weights_shape)
                 )
             self.weights_init = tf.constant_initializer(value=self.weights_init, dtype=tf.float32)
 
         elif isinstance(self.weights_init, np.ndarray):
-            if self.weights.shape != weights_shape:
+            if self.weights_init.shape != weights_shape:
                 raise TensorForceError(
-                    'Weights shape {} does not match expected shape {} '.format(self.weights.shape, weights_shape)
+                    'Weights shape {} does not match expected shape {} '.format(self.weights_init.shape, weights_shape)
                 )
             self.weights_init = tf.constant_initializer(value=self.weights_init, dtype=tf.float32)
 
         elif isinstance(self.weights_init, tf.Tensor):
             if util.shape(self.weights_init) != weights_shape:
                 raise TensorForceError(
-                    'Weights shape {} does not match expected shape {} '.format(self.weights.shape, weights_shape)
+                    'Weights shape {} does not match expected shape {} '.format(self.weights_init.shape, weights_shape)
                 )
 
         bias_shape = (self.size,)

--- a/tensorforce/core/networks/layer.py
+++ b/tensorforce/core/networks/layer.py
@@ -248,7 +248,7 @@ class Linear(Layer):
             if self.weights_init == 0.0:
                 self.weights_init = tf.zeros_initializer(dtype=tf.float32)
             else:
-                self.weights_init = tf.constant_initializer(value=self.weights, dtype=tf.float32)
+                self.weights_init = tf.constant_initializer(value=self.weights_init, dtype=tf.float32)
 
         elif isinstance(self.weights_init, list):
             self.weights_init = np.asarray(self.weights_init, dtype=np.float32)


### PR DESCRIPTION
This fixes "object has no attribute 'weights'" when trying to set weights using a float on a Linear layer