### PR TITLE
Revise DQN agent example config for new API

### DIFF
--- a/examples/configs/dqn_agent.json
+++ b/examples/configs/dqn_agent.json
@@ -15,25 +15,26 @@
   ],
 
   "batch_size": 32,
-  "memory_capacity": 10000,
   "memory": {
       "type": "replay",
-      "random_sampling": true
+      "random_sampling": true,
+      "capacity": 10000
   },
-  "update_frequency": 4,
   "first_update": 50000,
+  "update_frequency": 4,
   "repeat_update": 1,
-  "target_update_frequency": 10000,
-  "discount": 0.97,
-  "learning_rate": 0.00025,
+
   "optimizer": {
     "type": "rmsprop",
     "momentum": 0.95,
-    "epsilon": 0.01
+    "epsilon": 0.01,
+    "learning_rate": 0.00025
   },
-  "tf_summary": null,
-  "log_level": "info",
-  "update_target_weight": 1.0,
-  "double_dqn": false,
-  "clip_loss": 0.0
+  "discount": 0.97,
+  "target_sync_frequency": 10000,
+  "target_update_weight": 1.0,
+  "double_q_model": false,
+  "huber_loss": null,
+
+  "log_level": "info"
 }


### PR DESCRIPTION
This should address the errors that occur with existing config.
New keys from `default_config` dict have not been migrated yet.