### PR TITLE
Enhanced error handling for unknown objects

### DIFF
--- a/examples/configs/dqn_agent.json
+++ b/examples/configs/dqn_agent.json
@@ -15,25 +15,26 @@
   ],
 
   "batch_size": 32,
-  "memory_capacity": 10000,
   "memory": {
       "type": "replay",
-      "random_sampling": true
+      "random_sampling": true,
+      "capacity": 10000
   },
-  "update_frequency": 4,
   "first_update": 50000,
+  "update_frequency": 4,
   "repeat_update": 1,
-  "target_update_frequency": 10000,
-  "discount": 0.97,
-  "learning_rate": 0.00025,
+
   "optimizer": {
     "type": "rmsprop",
     "momentum": 0.95,
-    "epsilon": 0.01
+    "epsilon": 0.01,
+    "learning_rate": 0.00025
   },
-  "tf_summary": null,
-  "log_level": "info",
-  "update_target_weight": 1.0,
-  "double_dqn": false,
-  "clip_loss": 0.0
+  "discount": 0.97,
+  "target_sync_frequency": 10000,
+  "target_update_weight": 1.0,
+  "double_q_model": false,
+  "huber_loss": null,
+
+  "log_level": "info"
 }

--- a/tensorforce/util.py
+++ b/tensorforce/util.py
@@ -152,9 +152,13 @@ def get_object(obj, predefined_objects=None, default_object=None, kwargs=None):
     if predefined_objects is not None and obj in predefined_objects:
         obj = predefined_objects[obj]
     elif isinstance(obj, str):
-        module_name, function_name = obj.rsplit('.', 1)
-        module = importlib.import_module(module_name)
-        obj = getattr(module, function_name)
+        if obj.find('.') != -1:
+            module_name, function_name = obj.rsplit('.', 1)
+            module = importlib.import_module(module_name)
+            obj = getattr(module, function_name)
+        else:
+            predef_obj_keys = list(predefined_objects.keys())
+            raise TensorForceError("Error: object {} not found in predefined objects: {}".format(obj,predef_obj_keys))
     elif callable(obj):
         pass
     elif default_object is not None:


### PR DESCRIPTION
Should resolve the `ValueError` on `obj.rsplit()` when an unknown agent name is provided.

Example failure stimulus:
`python examples/openai_gym.py CartPole-v0 -a PPOAgent -c examples/configs/ppo_agent.json -n examples/configs/ppo_network.json` 

In the above case `PPOAgent` is not a valid option (it should be `ppo_agent` in the revised API) and we receive a non-intuitive error message:
`ValueError: not enough values to unpack (expected 2, got 1)`

With this fix, if the object string is not found, it will report a list of valid options.
