### PR TITLE
Minor: fix VPG LSTM example config

### DIFF
--- a/examples/configs/vpg_network_lstm.json
+++ b/examples/configs/vpg_network_lstm.json
@@ -8,6 +8,7 @@
         "size": 32
     },
     {
-        "type": "lstm"
+        "type": "lstm",
+        "size": 32
     }
 ]


### PR DESCRIPTION
Added missing size key for LSTM layer (VPG example config)