### PR TITLE
add summary_spec for 'inputs' show states,actions,rewards

### DIFF
--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -210,6 +210,16 @@ class Model(object):
                     deterministic=self.deterministic_input
                 )
 
+            if 'inputs' in self.summary_labels:
+                for name, state in states.items():
+                    summary = tf.summary.histogram(name='/input/states/'+name, values=state)
+                    self.summaries.append(summary)
+                for name, action in actions.items():                        
+                    summary = tf.summary.histogram(name='/input/actions/'+name, values=action)
+                    self.summaries.append(summary)
+                summary = tf.summary.histogram(name='/input/reward', values=reward)
+                self.summaries.append(summary)                           
+
         if distributed_spec is not None:
             if distributed_spec.get('replica_model'):
                 # If internal global model

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -625,6 +625,10 @@ class Model(object):
         losses = self.fn_regularization_losses(states=states, internals=internals, update=update)
         if len(losses) > 0:
             loss += tf.add_n(inputs=list(losses.values()))
+            if 'regularization' in self.summary_labels:
+                for name, loss_val in losses.items():
+                    summary = tf.summary.histogram(name="regularization/"+name, values=loss_val)
+                    self.summaries.append(summary)
 
         # Total loss summary
         if 'losses' in self.summary_labels or 'total-loss' in self.summary_labels:

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -627,7 +627,7 @@ class Model(object):
             loss += tf.add_n(inputs=list(losses.values()))
             if 'regularization' in self.summary_labels:
                 for name, loss_val in losses.items():
-                    summary = tf.summary.histogram(name="regularization/"+name, values=loss_val)
+                    summary = tf.summary.scalar(name="regularization/"+name, tensor=loss_val)
                     self.summaries.append(summary)
 
         # Total loss summary


### PR DESCRIPTION
This adds histograms for the States, Actions, and reward input values if "inputs" is added to the labels of the summary_specs

<img width="1926" alt="screenshot 2017-11-09 16 37 35" src="https://user-images.githubusercontent.com/18412448/32631942-ce3bcbd4-c56f-11e7-90bc-5b12e6d991bd.png">