### PR TITLE
Visualizing gym training

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -20,7 +20,7 @@ from tensorforce.execution import Runner
 from tensorforce.contrib.openai_gym import OpenAIGym
 
 # Create an OpenAIgym environment
-env = OpenAIGym('CartPole-v0')
+env = OpenAIGym('CartPole-v0', visualize=True)
 
 # Network as list of layers
 network_spec = [

--- a/tensorforce/contrib/openai_gym.py
+++ b/tensorforce/contrib/openai_gym.py
@@ -29,7 +29,7 @@ from tensorforce.environments import Environment
 
 class OpenAIGym(Environment):
 
-    def __init__(self, gym_id, monitor=None, monitor_safe=False, monitor_video=0):
+    def __init__(self, gym_id, monitor=None, monitor_safe=False, monitor_video=0, visualize=False):
         """
         Initialize OpenAI Gym.
 
@@ -38,10 +38,13 @@ class OpenAIGym(Environment):
             monitor: Output directory. Setting this to None disables monitoring.
             monitor_safe: Setting this to True prevents existing log files to be overwritten. Default False.
             monitor_video: Save a video every monitor_video steps. Setting this to 0 disables recording of videos.
+            visualize: If set True, the program will visualize the trainings of gym's environment. Note that such
+                visualization is probabily going to slow down the training.
         """
 
         self.gym_id = gym_id
         self.gym = gym.make(gym_id)  # Might raise gym.error.UnregisteredEnv or gym.error.DeprecatedEnv
+        self.visualize = visualize
 
         if monitor:
             if monitor_video == 0:
@@ -63,6 +66,8 @@ class OpenAIGym(Environment):
         return self.gym.reset()
 
     def execute(self, actions):
+        if self.visualize:
+            self.gym.render()
         state, reward, terminal, _ = self.gym.step(actions)
         return state, terminal, reward
 


### PR DESCRIPTION
It might be desirable to visualize the training of agents for two reasons. 

* A person might get a better understanding of the agent's performance by eyeballing the training process rather than the scalar reward. 
* It would be visualizing appealing for demo purposes

Thus, I added a simple parameter to enable such feature over gym's environment. One could use 

``env = OpenAIGym('CartPole-v0', visualize=True)``

to visualize the training process. 

![image](https://user-images.githubusercontent.com/5555347/33151408-fef62586-cfa5-11e7-9a2c-aa779eaf80d1.png)
