### PR TITLE
Fix a bug with generating multiple actions

### DIFF
--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -231,7 +231,7 @@ class Agent(object):
         if self.unique_action:
             return self.current_actions['action']
         else:
-            return [values for values in self.current_actions.values()]
+            return self.current_actions 
 
     def observe(self, terminal, reward):
         """

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -231,7 +231,7 @@ class Agent(object):
         if self.unique_action:
             return self.current_actions['action']
         else:
-            return self.current_actions 
+            return self.current_actions
 
     def observe(self, terminal, reward):
         """

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -231,7 +231,7 @@ class Agent(object):
         if self.unique_action:
             return self.current_actions['action']
         else:
-            return self.current_actions
+            return [values for values in self.current_actions.values()]
 
     def observe(self, terminal, reward):
         """

--- a/tensorforce/contrib/openai_gym.py
+++ b/tensorforce/contrib/openai_gym.py
@@ -68,6 +68,9 @@ class OpenAIGym(Environment):
     def execute(self, actions):
         if self.visualize:
             self.gym.render()
+        # if the actions is not unique, that is, if the actions is a dict
+        if type(actions) == dict:
+            actions = [values for values in actions.values()]
         state, reward, terminal, _ = self.gym.step(actions)
         return state, terminal, reward
 


### PR DESCRIPTION
I was trying to run the [quickstart code on ReversedAddition-v0](https://gist.github.com/vwxyzjn/d906703cdd96f84808c40a40aa8fe64e),
but I got the following error message:

```python
Traceback (most recent call last):

  File "<ipython-input-1-411cd64b2471>", line 1, in <module>
    runfile('F:/grad school/tensorforce/tensorforce/examples/quickstart.py', wdir='F:/grad school/tensorforce/tensorforce/examples')

  File "C:\Users\costa\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 688, in runfile
    execfile(filename, namespace)

  File "C:\Users\costa\Anaconda3\lib\site-packages\spyder\utils\site\sitecustomize.py", line 101, in execfile
    exec(compile(f.read(), filename, 'exec'), namespace)

  File "F:/grad school/tensorforce/tensorforce/examples/quickstart.py", line 84, in <module>
    runner.run(episodes=10, max_episode_timesteps=200, episode_finished=episode_finished)

  File "f:\grad school\tensorforce\tensorforce\tensorforce\execution\runner.py", line 106, in run
    state, terminal, reward = self.environment.execute(actions=action)

  File "f:\grad school\tensorforce\tensorforce\tensorforce\contrib\openai_gym.py", line 72, in execute
    state, reward, terminal, _ = self.gym.step(actions)

  File "C:\Users\costa\Anaconda3\lib\site-packages\gym\core.py", line 96, in step
    return self._step(action)

  File "C:\Users\costa\Anaconda3\lib\site-packages\gym\wrappers\time_limit.py", line 36, in _step
    observation, reward, done, info = self.env.step(action)

  File "C:\Users\costa\Anaconda3\lib\site-packages\gym\core.py", line 96, in step
    return self._step(action)

  File "C:\Users\costa\Anaconda3\lib\site-packages\gym\envs\algorithmic\algorithmic_env.py", line 165, in _step
    assert self.action_space.contains(action)

AssertionError
```

After further investigation, I found that the agent would produce actions ``{'action0': 3, 'action1': 1, 'action2': 2}``, while the model is expecting ``[3,1,2]``. Notice that

```python
action1 = {'action0': 3, 'action1': 1, 'action2': 2}

action2 = [3,1,2]

env.gym.action_space.contains(action1)
Out[4]: False

env.gym.action_space.contains(action2)
Out[5]: True
```

After such realization, I went to see the code in ``\tensorforce\tensorforce\agents\agent.py`` and found the relevant line [here](https://github.com/reinforceio/tensorforce/blob/eef5c7c79d276519fed4681454bd377142e6bc27/tensorforce/agents/agent.py#L230)

Basically, when action is unique, the ``act()`` return ``self.current_actions['action']``, which would, for example, produce a single value ``2``, rather than ``{'action': 2}``. However, ``act()`` does not consistently do this for multiple actions.

For example, the ``agent.act()`` would generate ``{'action0': 2, 'action1': 1, 'action2': 0}``, while the modified ``agent.act()`` will generate ``[0,0,1]``