### PR TITLE
Update index upon set_memory()

### DIFF
--- a/tensorforce/core/memories/replay.py
+++ b/tensorforce/core/memories/replay.py
@@ -162,6 +162,8 @@ class Replay(Memory):
                 self.actions[name] = np.asarray(action)
             self.terminal = np.asarray(terminal)
             self.reward = np.asarray(reward)
+            # Filled capacity to point of index wrap
+            self.index = 0
 
         else:
             # Otherwise partial assignment.
@@ -177,3 +179,4 @@ class Replay(Memory):
                 self.actions[name][:len(action)] = action
             self.terminal[:len(terminal)] = terminal
             self.reward[:len(reward)] = reward
+            self.index = len(terminal)


### PR DESCRIPTION
I believe the buffer indices will get out of sync in the current implementation should `set_memory()` be called instead of `add_observation()`. This fix has not been fully tested.