### PR TITLE
quickstart guidance re: embedding for gym discrete obs space

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -23,7 +23,15 @@ from tensorforce.contrib.openai_gym import OpenAIGym
 env = OpenAIGym('CartPole-v0', visualize=True)
 
 # Network as list of layers
+# - Embedding layer:
+#   - For Gym environments utilizing a discrete observation space, an
+#     "embedding" layer should be inserted at the head of the network spec.
+#     Such environments are usually identified by either:
+#     - class ...Env(discrete.DiscreteEnv):
+#     - self.observation_space = spaces.Discrete(...)
+#   
 network_spec = [
+    #dict(type='embedding', indices=100, size=32),
     dict(type='dense', size=32, activation='tanh'),
     dict(type='dense', size=32, activation='tanh')
 ]


### PR DESCRIPTION
Minor update: Might be helpful for those using `quickstart.py` to be aware of the need to adapt discrete OpenAI gym observation spaces to the tensor of floats required by existing TensorForce layers. Added brief note but feel free to adjust (eg. drop identification text) as appropriate.