### PR TITLE
Complex Network Implementation

### DIFF
--- a/tensorforce/core/networks/__init__.py
+++ b/tensorforce/core/networks/__init__.py
@@ -16,6 +16,7 @@
 from tensorforce.core.networks.layer import Layer, Nonlinearity, Dropout, Flatten, Pool2d, Embedding, Linear, Dense, \
     Dueling, Conv1d, Conv2d, InternalLstm, Lstm
 from tensorforce.core.networks.network import Network, LayerBasedNetwork, LayeredNetwork
+from tensorforce.core.networks.complex_network import Input, Output
 
 
 layers = dict(
@@ -30,7 +31,9 @@ layers = dict(
     conv1d=Conv1d,
     conv2d=Conv2d,
     internal_lstm=InternalLstm,
-    lstm=Lstm
+    lstm=Lstm,
+    input=Input,
+    output=Output   
 )
 
 
@@ -41,12 +44,14 @@ __all__ = [
     'Dropout',
     'Flatten',
     'Pool2d',
+    'Embedding',
     'Linear',
     'Dense',
     'Dueling',
     'Conv1d',
     'Conv2d',
     'InternalLstm',
+    'Lstm',
     'Network',
     'LayerBasedNetwork',
     'LayeredNetwork'

--- a/tensorforce/core/networks/complex_network.py
+++ b/tensorforce/core/networks/complex_network.py
@@ -1,0 +1,187 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from collections import Counter
+import json
+import os
+
+import tensorflow as tf
+
+from tensorforce import util, TensorForceError
+from tensorforce.core.networks import Layer
+from tensorforce.core.networks.network import LayerBasedNetwork
+
+class Input(Layer):
+    """
+    Input layer. Used for ComplexLayerNetwork's to collect data together
+    as a form of output to the next layer.  Allows for multiple inputs
+    to merge into a single import for next layer.  
+    """
+    def __init__(
+        self, 
+        inputs, 
+        axis=1,
+        scope='merge_inputs', 
+        summary_labels=()):
+        """
+        Input layer.
+
+        Args:
+            inputs: A list of strings that name the inputs to merge
+            axis: Axis to merge the inputs
+
+        """        
+        self.inputs = inputs
+        self.axis = axis
+        super(Input, self).__init__(scope=scope, summary_labels=summary_labels)
+
+    def tf_apply(self, x, update):
+        inputs_to_merge = list()
+        for name in self.inputs:
+            # Previous input, by name or "*", like normal network_spec
+            # Not using named_tensors as there could be unintended outcome 
+            if name == "*" or name == "previous":  
+                inputs_to_merge.append(x)
+            elif name in self.named_tensors:
+                inputs_to_merge.append(self.named_tensors[name])
+            else:
+                # Failed to find key in available inputs, print out help to user, raise error
+                keys=list(self.named_tensors)
+                raise TensorForceError(
+                    'ComplexNetwork input "{}" doesn\'t exist, Available inputs: {}'.format(name,keys)
+                )    
+        # Review data for casting to more precise format so TensorFlow doesn't throw error for mixed data
+        # Quick & Dirty cast only promote types: bool=0,int32=10, int64=20, float32=30, double=40
+        #            
+        cast_type_level = 0
+        cast_type_dict = {'bool':0, 'int32':10, 'int64':20, 'float32':30, 'float64':40}                
+        cast_type_func_dict = {0:tf.identity, 10:tf.to_int32, 20:tf.to_int64, 30:tf.to_float, 40:tf.to_double}    
+        # Scan inputs for max cast_type            
+        for tensor in inputs_to_merge:
+            key=str(tensor.dtype.name)
+            if key in cast_type_dict:
+                if cast_type_dict[key] > cast_type_level:
+                    cast_type_level = cast_type_dict[key]
+            else:
+                raise TensorForceError('Network spec "input" doesn\'t support dtype {}'.format(keys)
+   
+        # Add casting if needed
+        for index,tensor in enumerate(inputs_to_merge):
+            key=str(tensor.dtype.name)
+            if cast_type_dict[key] < cast_type_level:
+                inputs_to_merge[index]=cast_type_func_dict[cast_type_level](tensor)
+
+        input_tensor = tf.concat(inputs_to_merge,self.axis)
+        return input_tensor
+
+
+class Output(Layer):
+    """
+    Output layer. Used for ComplexLayerNetwork's to capture the tensor
+    under and name for use with Input layers.  Acts as a input to output passthrough.
+    """
+    def __init__(self,
+        output,
+        scope='output',
+        summary_labels=()):
+        """
+        Output layer.
+
+        Args:
+            output: A string that names the tensor, will be added to available inputs
+
+        """  
+        self.output = output
+        super(Output, self).__init__(scope=scope, summary_labels=summary_labels)
+
+    def tf_apply(self, x, update):
+        self.named_tensors[self.output]=x
+        return x
+
+
+class ComplexLayeredNetwork(LayerBasedNetwork):
+    """
+    Complex Network consisting of a sequence of layers, which can be created from a specification dict.
+    """
+    def __init__(self, complex_layers_spec, scope='layered-network', summary_labels=()):
+        """
+        Complex Layered network.
+
+        Args:
+            complex_layers_spec: List of layer specification dicts
+        """
+        super(ComplexLayeredNetwork, self).__init__(scope=scope, summary_labels=summary_labels)
+        self.complex_layers_spec = complex_layers_spec
+        self.Inputs = dict()
+
+        layer_counter = Counter()
+
+        for branch_spec in self.complex_layers_spec:
+            for layer_spec in branch_spec:
+                if isinstance(layer_spec['type'], str):
+                    name = layer_spec['type']
+                else:
+                    name = 'layer'
+                scope = name + str(layer_counter[name])
+                layer_counter[name] += 1
+
+                layer = Layer.from_spec(
+                    spec=layer_spec,
+                    kwargs=dict(scope=scope, summary_labels=summary_labels)
+                )
+                # Link named dictionary reference into Layer
+                layer.tf_tensors(named_tensors=self.Inputs)
+                self.add_layer(layer=layer)
+
+    def tf_apply(self, x, internals, update, return_internals=False):
+        if isinstance(x, dict):
+            self.Inputs.update(x) 
+            if len(x) == 1:              
+                x = next(iter(x.values()))         
+
+        internal_outputs = list()
+        index = 0
+        for layer in self.layers:
+            layer_internals = [internals[index + n] for n in range(layer.num_internals)]
+            index += layer.num_internals
+            x = layer.apply(x, update, *layer_internals)
+
+            if not isinstance(x, tf.Tensor):
+                internal_outputs.extend(x[1])
+                x = x[0]
+
+        if return_internals:
+            return x, internal_outputs
+        else:
+            return x
+
+    @staticmethod
+    def from_json(filename):  # TODO: NOT TESTED
+        """
+        Creates a complex_layered_network_builder from a JSON.
+
+        Args:
+            filename: Path to configuration
+
+        Returns: A ComplexLayeredNetwork class with layers generated from the JSON
+        """
+        path = os.path.join(os.getcwd(), filename)
+        with open(path, 'r') as fp:
+            config = json.load(fp=fp)
+        return ComplexLayeredNetwork(layers_spec=config)

--- a/tensorforce/core/networks/network.py
+++ b/tensorforce/core/networks/network.py
@@ -129,11 +129,26 @@ class Network(object):
         """
         Creates a network from a specification dict.
         """
-        network = util.get_object(
-            obj=spec,
-            default_object=LayeredNetwork,
-            kwargs=kwargs
-        )
+        network=None
+        if len(spec)>0:
+            # ComplexLayeredNetwork forced for testing
+            if type(spec[0]) is list:
+                # Spec contains List of List of Dict(), Complex network specification
+                # Load "ComplexLayeredNetwork" here to avoid a recurring loop which fails
+                from tensorforce.core.networks.complex_network import ComplexLayeredNetwork
+                network = util.get_object(
+                    obj=spec,
+                    default_object=ComplexLayeredNetwork,
+                    kwargs=kwargs
+                )
+            if type(spec[0]) is dict:
+                # Spec contains List of Dict(), Layered network specification
+                network = util.get_object(
+                    obj=spec,
+                    default_object=LayeredNetwork,
+                    kwargs=kwargs
+                )   
+        # If neither format, invalid spec and will fail on assert             
         assert isinstance(network, Network)
         return network
 


### PR DESCRIPTION
ComplexNetwork basic implementation:

    network_spec_CL_selu_cp = [ 
        [
            dict(type='input', inputs=['state']),
            dict(type='dense', size=50, activation='selu', skip=False,l1_regularization=.00,l2_regularization=.0002),
            dict(type='dense', size=25, activation='selu', skip=False,l1_regularization=.00,l2_regularization=.0002),
            dict(type='dueling', size=3, activation='none', output=('expectation1','advantage1','mean_advantage2'),
                summary_labels=['activations','expectation','advantage','mean_advantage']),               
            dict(type='output', output='skip'),
            dict(type='dense', size=3, activation='selu', skip=False,l1_regularization=.00,l2_regularization=.0002),
            dict(type='input', inputs=['*','skip']),            
            dict(type='dense', size=3, activation='selu', skip=False,l1_regularization=.00,l2_regularization=.0002),
            dict(type='dueling', size=3, activation='none', output=('expectation2','advantage2','mean_advantage2'),
                summary_labels=['activations','expectation','advantage','mean_advantage']),
            dict(type='output', output='actions'),   
        ],
        [
            dict(type='input', inputs=['*','advantage1']), 
            #dict(type='input', inputs=['actions','advantage']),    # Same as above                    
            dict(type='dense', size=None, activation='selu', skip=True,l1_regularization=.00,l2_regularization=.0002),
            dict(type='dense', size=None, activation='selu', skip=True,l1_regularization=.00,l2_regularization=.0002),
            dict(type='dueling', size=3, activation='none', output=('expectation3','advantage3','mean_advantage3'),
                summary_labels=['activations','expectation','advantage','mean_advantage']),            
        ]    
    ] 

The ComplexNetwork is a List of List of Dict vs LayeredNetwork which is a List of Dict.
Output from the previous Dict() is available to the next Dict() regardless of network structure.

The Input layer will accept named inputs as a list where '*' or 'previous' means output from the previous dict.  This allows inline concatenation from earlier steps.  Outputs can be created inline as well to create skips, etc.  Some Layer types can support naming internal calculates for external use, such as "dueling".  The advantage will be useful in some later steps if this layer is used early in a network.