### PR TITLE
Add swish non-linear activation function

### DIFF
--- a/tensorforce/core/networks/layer.py
+++ b/tensorforce/core/networks/layer.py
@@ -192,6 +192,11 @@ class Nonlinearity(Layer):
         elif self.name == 'sigmoid':
             x = tf.sigmoid(x=x)
 
+        elif self.name == 'swish':
+            # https://arxiv.org/abs/1710.05941
+            # TODO: Look into adding learnable "beta" as paper describes
+            x = tf.sigmoid(x=x) * x    
+            
         elif self.name == 'softmax':
             x = tf.nn.softmax(logits=x)
 


### PR DESCRIPTION
Added swish as described here:
https://arxiv.org/abs/1710.05941

This paper describes a "Beta" parameter as well which technically could be applied to any non-linearity. 
 This may be something we want to consider enabling, doesn't make sense in some activations but others it does.  I will open another discussion for a "learnable Beta" value.