### PR TITLE
Runner requires manual call to close() so calling-code can work with "dirty" runner

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,7 @@ In python, it could look like this:
 
    # Start learning
    runner.run(episodes=3000, max_episode_timesteps=200, episode_finished=episode_finished)
+   runner.close()
 
    # Print statistics
    print("Learning finished. Total episodes: {ep}. Average reward of last 100 episodes: {ar}.".format(

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -47,6 +47,7 @@ runner.run(
     max_timesteps = int,  # maximum timesteps per episode
     episode_finished = object,  # callback function called when episode is finished
 )
+runner.close()
 ```
 
 You can use the episode\_finished callback for printing performance
@@ -104,6 +105,7 @@ def main():
     print("Starting {agent} for Environment '{env}'".format(agent=agent, env=env))
 
     runner.run(max_episodes, max_timesteps, episode_finished=episode_finished)
+    runner.close()
 
     print("Learning finished. Total episodes: {ep}".format(ep=runner.episode))
 

--- a/examples/ale.py
+++ b/examples/ale.py
@@ -121,6 +121,7 @@ def main():
 
     logger.info("Starting {agent} for Environment '{env}'".format(agent=agent, env=environment))
     runner.run(args.episodes, args.max_timesteps, episode_finished=episode_finished)
+    runner.close()
     logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.episode))
 
     environment.close()

--- a/examples/lab_main.py
+++ b/examples/lab_main.py
@@ -136,6 +136,7 @@ def main():
 
     logger.info("Starting {agent} for Lab environment '{env}'".format(agent=agent, env=environment))
     runner.run(args.episodes, args.max_timesteps, episode_finished=episode_finished)
+    runner.close()
     logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.episode + 1))
 
     environment.close()

--- a/examples/maze_explorer.py
+++ b/examples/maze_explorer.py
@@ -117,6 +117,7 @@ def main():
 
     logger.info("Starting {agent} for Environment '{env}'".format(agent=agent, env=environment))
     runner.run(args.episodes, args.max_timesteps, episode_finished=episode_finished)
+    runner.close()
     logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.episode))
 
     if args.monitor:

--- a/examples/openai_gym.py
+++ b/examples/openai_gym.py
@@ -129,6 +129,7 @@ def main():
         deterministic=args.deterministic,
         episode_finished=episode_finished
     )
+    runner.close()
 
     logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.agent.episode))
 

--- a/examples/openai_gym_async.py
+++ b/examples/openai_gym_async.py
@@ -227,6 +227,7 @@ def main():
         deterministic=args.deterministic,
         episode_finished=episode_finished
     )
+    runner.close()
 
 
 if __name__ == '__main__':

--- a/examples/openai_universe.py
+++ b/examples/openai_universe.py
@@ -120,6 +120,7 @@ def main():
 
     logger.info("Starting {agent} for Environment '{env}'".format(agent=agent, env=environment))
     runner.run(args.episodes, args.max_timesteps, episode_finished=episode_finished)
+    runner.close()
     logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.episode))
 
     # if args.monitor:

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -83,6 +83,7 @@ def episode_finished(r):
 
 # Start learning
 runner.run(episodes=3000, max_episode_timesteps=200, episode_finished=episode_finished)
+runner.close()
 
 # Print statistics
 print("Learning finished. Total episodes: {ep}. Average reward of last 100 episodes: {ar}.".format(

--- a/examples/unreal_engine.py
+++ b/examples/unreal_engine.py
@@ -161,6 +161,7 @@ def main():
         deterministic=args.deterministic,
         episode_finished=episode_finished
     )
+    runner.close()
 
     logger.info("Learning finished. Total episodes: {ep}".format(ep=runner.agent.episode))
 

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -64,6 +64,10 @@ class Runner(object):
         self.episode_timesteps = history.get('episode_timesteps', list())
         self.episode_times = history.get('episode_times', list())
 
+    def close(self):
+        self.agent.close()
+        self.environment.close()
+
     def run(
         self,
         timesteps=None,
@@ -147,6 +151,3 @@ class Runner(object):
                     self.agent.should_stop():
                 # agent.episode / agent.timestep are globally updated
                 break
-
-        self.agent.close()
-        self.environment.close()

--- a/tensorforce/tests/base_test.py
+++ b/tensorforce/tests/base_test.py
@@ -80,6 +80,7 @@ class BaseTest(object):
                 return r.episode < 100 or not all(episodes_passed)
 
             runner.run(episodes=3000, deterministic=self.__class__.deterministic, episode_finished=episode_finished)
+            runner.close()
 
             sys.stdout.write(' ' + str(runner.episode))
             sys.stdout.flush()
@@ -128,6 +129,7 @@ class BaseTest(object):
             return r.episode < 100 or not all(episodes_passed)
 
         runner.run(episodes=100, deterministic=self.__class__.deterministic, episode_finished=episode_finished)
+        runner.close()
 
         sys.stdout.write('==> {} ran\n'.format(1))
         sys.stdout.flush()

--- a/tensorforce/tests/test_quickstart_example.py
+++ b/tensorforce/tests/test_quickstart_example.py
@@ -78,6 +78,7 @@ class TestQuickstartExample(unittest.TestCase):
 
             # Start the runner
             runner.run(episodes=2000, max_episode_timesteps=200, episode_finished=episode_finished)
+            runner.close()
 
             sys.stdout.write('episodes: {}\n'.format(runner.episode))
             sys.stdout.flush()

--- a/tensorforce/tests/test_tutorial_code.py
+++ b/tensorforce/tests/test_tutorial_code.py
@@ -432,6 +432,7 @@ class TestTutorialCode(unittest.TestCase):
 
         # runner.run(episodes=1000, episode_finished=episode_finished)
         runner.run(episodes=10, episode_finished=episode_finished)  # Only 10 episodes for this test
+        runner.close()
 
         ### Code block: next
         agent = DQNAgent(


### PR DESCRIPTION
A conversation I'd had earlier with @AlexKuhnle - in order to do cross-validation, or alternating train/test, we came to doing this:

```python
# Train
runner = Runner(agent=agent, environment=env)
runner.run(timesteps=...)

# Test
next_state, terminal = env.reset(), False
while not terminal:
    next_state, terminal, reward = env.execute(agent.act(next_state, deterministic=True))
```

With the current TensorForce code, the Test segment will fail because agent & model will have been closed automatically (in the end of `runner.run()`). For consideration: this PR which requires manually closing `runner`, or possibly a method argument such as `auto_close=True`.