### PR TITLE
Unify Runner classes via BaseRunner parent class

### DIFF
--- a/examples/threaded_ale.py
+++ b/examples/threaded_ale.py
@@ -175,7 +175,8 @@ def main():
 
     # Create runners
     threaded_runner = ThreadedRunner(
-        agents, environments,
+        agents,
+        environments,
         repeat_actions=1,
         save_path=args.save,
         save_episodes=args.save_episodes
@@ -183,9 +184,8 @@ def main():
 
     logger.info("Starting {agent} for Environment '{env}'".format(agent=agent, env=environments[0]))
     threaded_runner.run(summary_interval=100, episode_finished=episode_finished, summary_report=summary_report)
+    threaded_runner.close()
     logger.info("Learning finished. Total episodes: {ep}".format(ep=threaded_runner.global_episode))
-
-    [environments[t].close() for t in range(args.workers)]
 
 
 if __name__ == '__main__':

--- a/examples/unreal_engine.py
+++ b/examples/unreal_engine.py
@@ -65,7 +65,7 @@ def main():
 
     args = parser.parse_args()
 
-    #logging.basicConfig(filename="logfile.txt", level=logging.INFO)
+    # logging.basicConfig(filename="logfile.txt", level=logging.INFO)
     logging.basicConfig(stream=sys.stderr)
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)

--- a/examples/unreal_engine.py
+++ b/examples/unreal_engine.py
@@ -83,7 +83,7 @@ def main():
     if args.random_test_run:
         # Reset the env.
         s = environment.reset()
-        img = Image.fromarray(s, "RGB")
+        img = Image.fromarray(s, "RGB" if len(environment.states["shape"]) == 3 else "L")
         # Save first received image as a sanity-check.
         img.save("reset.png")
         for i in range(1000):

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -110,7 +110,7 @@ class Agent(object):
     def reset(self):
         """
         Reset the agent to its initial state (e.g. on experiment start). Updates the Model's internal episode and
-        timestep counter, internal states, and resets preprocessors.
+        time step counter, internal states, and resets preprocessors.
         """
         self.episode, self.timestep, self.next_internals = self.model.reset()
         self.current_internals = self.next_internals

--- a/tensorforce/contrib/unreal_engine.py
+++ b/tensorforce/contrib/unreal_engine.py
@@ -28,7 +28,7 @@ class UE4Environment(RemoteEnvironment, StateSettableEnvironment):
     """
     A special RemoteEnvironment for UE4 game connections.
     Communicates with the remote to receive information on the definitions of action- and observation spaces.
-    Sends UE4 Action- and Axis-mappings as RL-actions and receives observations back defined by ducandu plugin Observer
+    Sends UE4 Action- and Axis-mappings as RL-actions and receives observations back defined by MLObserver
     objects placed in the Game
     (these could be camera pixels or other observations, e.g. a x/y/z position of some game actor).
     """

--- a/tensorforce/contrib/unreal_engine.py
+++ b/tensorforce/contrib/unreal_engine.py
@@ -86,6 +86,8 @@ class UE4Environment(RemoteEnvironment, StateSettableEnvironment):
             raise TensorForceError("ERROR in UE4Environment.connect: no observation- or action-space-desc sent "
                                    "by remote server!")
 
+        # game's name
+        self.game_name = response.get("game_name")  # keep non-mandatory for now
         # Observers
         self.observation_space_desc = response["observation_space_desc"]
         # Action-mappings

--- a/tensorforce/contrib/unreal_engine.py
+++ b/tensorforce/contrib/unreal_engine.py
@@ -86,7 +86,7 @@ class UE4Environment(RemoteEnvironment, StateSettableEnvironment):
             raise TensorForceError("ERROR in UE4Environment.connect: no observation- or action-space-desc sent "
                                    "by remote server!")
 
-        # game's name
+        # Game's name
         self.game_name = response.get("game_name")  # keep non-mandatory for now
         # Observers
         self.observation_space_desc = response["observation_space_desc"]

--- a/tensorforce/core/distributions/categorical.py
+++ b/tensorforce/core/distributions/categorical.py
@@ -56,7 +56,7 @@ class Categorical(Distribution):
 
         # Softmax for corresponding probabilities
         # TODO deprecated call, update when >1.5 becomes default install
-        probabilities = tf.nn.softmax(logits=logits, dim=-1)
+        probabilities = tf.nn.softmax(logits=logits, axis=-1)
 
         # Min epsilon probability for numerical stability
         probabilities = tf.maximum(x=probabilities, y=util.epsilon)

--- a/tensorforce/core/distributions/categorical.py
+++ b/tensorforce/core/distributions/categorical.py
@@ -56,7 +56,7 @@ class Categorical(Distribution):
 
         # Softmax for corresponding probabilities
         # TODO deprecated call, update when >1.5 becomes default install
-        probabilities = tf.nn.softmax(logits=logits, axis=-1)
+        probabilities = tf.nn.softmax(logits=logits, dim=-1)
 
         # Min epsilon probability for numerical stability
         probabilities = tf.maximum(x=probabilities, y=util.epsilon)

--- a/tensorforce/core/preprocessing/grayscale.py
+++ b/tensorforce/core/preprocessing/grayscale.py
@@ -34,7 +34,7 @@ class Grayscale(Preprocessor):
 
     def tf_process(self, tensor):
         weights = tf.reshape(tensor=self.weights, shape=(tuple(1 for _ in range(util.rank(tensor) - 1)) + (3,)))
-        return tf.reduce_sum(input_tensor=(weights * tensor), axis=-1, keep_dims=True)
+        return tf.reduce_sum(input_tensor=(weights * tensor), axis=-1, keepdims=True)
 
     def processed_shape(self, shape):
         return tuple(shape[:-1]) + (1,)

--- a/tensorforce/environments/__init__.py
+++ b/tensorforce/environments/__init__.py
@@ -15,5 +15,11 @@
 
 
 from tensorforce.environments.environment import Environment
+from tensorforce.environments.minimal_test import MinimalTest
 
-__all__ = ['Environment']
+
+environments = dict(
+    minimal_test=MinimalTest,
+)
+
+__all__ = ['Environment', 'MinimalTest']

--- a/tensorforce/environments/environment.py
+++ b/tensorforce/environments/environment.py
@@ -18,6 +18,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
+import tensorforce.environments
+import tensorforce.util
+
 
 class Environment(object):
     """
@@ -84,3 +87,16 @@ class Environment(object):
 
         """
         raise NotImplementedError
+
+    @staticmethod
+    def from_spec(spec, kwargs):
+        """
+        Creates an environment from a specification dict.
+        """
+        env = tensorforce.util.get_object(
+            obj=spec,
+            predefined_objects=tensorforce.environments.environments,
+            kwargs=kwargs
+        )
+        assert isinstance(env, Environment)
+        return env

--- a/tensorforce/environments/environment.py
+++ b/tensorforce/environments/environment.py
@@ -89,7 +89,7 @@ class Environment(object):
         raise NotImplementedError
 
     @staticmethod
-    def from_spec(spec,     kwargs):
+    def from_spec(spec, kwargs):
         """
         Creates an environment from a specification dict.
         """

--- a/tensorforce/environments/environment.py
+++ b/tensorforce/environments/environment.py
@@ -89,7 +89,7 @@ class Environment(object):
         raise NotImplementedError
 
     @staticmethod
-    def from_spec(spec, kwargs):
+    def from_spec(spec,     kwargs):
         """
         Creates an environment from a specification dict.
         """

--- a/tensorforce/execution/__init__.py
+++ b/tensorforce/execution/__init__.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
-from tensorforce.execution.runner import Runner
+from tensorforce.execution.base_runner import BaseRunner
+from tensorforce.execution.runner import Runner, SingleRunner, DistributedTFRunner
 from tensorforce.execution.threaded_runner import ThreadedRunner, WorkerAgentGenerator
 
-__all__ = ['Runner', 'ThreadedRunner', 'WorkerAgentGenerator']
+__all__ = ['BaseRunner', 'SingleRunner', 'DistributedTFRunner', 'Runner', 'ThreadedRunner', 'WorkerAgentGenerator']

--- a/tensorforce/execution/__init__.py
+++ b/tensorforce/execution/__init__.py
@@ -14,6 +14,6 @@
 # ==============================================================================
 
 from tensorforce.execution.runner import Runner
-from tensorforce.execution.threaded_runner import ThreadedRunner
+from tensorforce.execution.threaded_runner import ThreadedRunner, WorkerAgentGenerator
 
-__all__ = ['Runner', 'ThreadedRunner']
+__all__ = ['Runner', 'ThreadedRunner', 'WorkerAgentGenerator']

--- a/tensorforce/execution/base_runner.py
+++ b/tensorforce/execution/base_runner.py
@@ -1,0 +1,112 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+
+class BaseRunner(object):
+    """
+    Base class for all runner classes.
+    Implements the `run` method.
+    """
+    def __init__(self, agent, environment, repeat_actions=1, history=None):
+        """
+        Args:
+            agent (Agent): Agent object (or list of Agent objects) to use for the run.
+            environment (Environment): Environment object (or list of Environment objects) to use for the run.
+            repeat_actions (int): How many times the same given action will be repeated in subsequent calls to
+                Environment's `execute` method. Rewards collected in these calls are accumulated and reported
+                as a sum in the following call to Agent's `observe` method.
+            history (dict): A dictionary containing an already run experiment's results. Keys should be:
+                episode_rewards (list of rewards), episode_timesteps (lengths of episodes), episode_times (run-times)
+        """
+        self.agent = agent
+        self.environment = environment
+        self.repeat_actions = repeat_actions
+
+        self.global_episode = None  # the global episode number (across all (parallel) agents)
+        self.global_timestep = None  # the global time step (across all (parallel) agents)
+
+        self.start_time = None  # TODO: is this necessary here? global start time (episode?, overall?)
+
+        # lists of episode data (rewards, wall-times/timesteps)
+        self.episode_rewards = None  # list of accumulated episode rewards
+        self.episode_timesteps = None  # list of total timesteps taken in the episodes
+        self.episode_times = None  # list of durations for the episodes
+
+        self.reset(history)
+
+    def reset(self, history=None):
+        """
+        Resets the Runner's internal stats counters.
+        If history is empty, use default values in history.get().
+
+        Args:
+            history (dict): A dictionary containing an already run experiment's results. Keys should be:
+                episode_rewards (list of rewards), episode_timesteps (lengths of episodes), episode_times (run-times)
+        """
+        if not history:
+            history = dict()
+
+        self.episode_rewards = history.get("episode_rewards", list())
+        self.episode_timesteps = history.get("episode_timesteps", list())
+        self.episode_times = history.get("episode_times", list())
+
+    def close(self):
+        """
+        Should perform clean up operations on Runner's Agent(s) and Environment(s).
+        """
+        raise NotImplementedError
+
+    def run(self, num_episodes, num_timesteps, max_episode_timesteps, deterministic, episode_finished, summary_report,
+            summary_interval):
+        """
+        Executes this runner by starting to act (via Agent(s)) in the given Environment(s).
+        Stops execution according to certain conditions (e.g. max. number of episodes, etc..).
+        Calls callback functions after each episode and/or after some summary criteria are met.
+
+        Args:
+            num_episodes (int): Max. number of episodes to run globally in total (across all threads/workers).
+            num_timesteps (int): Max. number of time steps to run globally in total (across all threads/workers)
+            max_episode_timesteps (int): Max. number of timesteps per episode.
+            deterministic (bool): Whether to use exploration when selecting actions.
+            episode_finished (callable): A function to be called once an episodes has finished. Should take
+                a BaseRunner object and some worker ID (e.g. thread-ID or task-ID). Can decide for itself
+                every how many episodes it should report something and what to report.
+            summary_report (callable): Deprecated; Function that could produce a summary over the training
+                progress so far.
+            summary_interval (int): Deprecated; The number of time steps to execute (globally)
+                before summary_report is called.
+        """
+        raise NotImplementedError
+
+    # keep backwards compatibility
+    @property
+    def episode(self):
+        """
+        Deprecated property `episode` -> global_episode.
+        """
+        return self.global_episode
+
+    @property
+    def timestep(self):
+        """
+        Deprecated property `timestep` -> global_timestep.
+        """
+        return self.global_timestep
+
+

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -17,90 +17,70 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
+from tensorforce.execution.base_runner import BaseRunner
+
 import time
 from six.moves import xrange
+import warnings
+from inspect import signature
 
 
-class Runner(object):
+class Runner(BaseRunner):
     """
     Simple runner for non-realtime single-process execution.
     """
 
-    def __init__(self, agent, environment, repeat_actions=1, history=None):
+    def __init__(self, agent, environment, repeat_actions=1, history=None, id_=0):
         """
         Initialize a single Runner object (one Agent/one Environment).
 
         Args:
-            agent (Agent): Agent object to use for the run.
-            environment (Environment): Environment object to use for the run.
-            repeat_actions (int): How many times the same given action will be repeated in subsequent calls to
-                Environment's `execute` method. Rewards collected in these calls are accumulated and reported
-                as a sum in the following call to Agent's `observe` method.
-            history (dict): A dictionary containing an already run experiment's results. Keys should be:
-                episode_rewards (list of rewards), episode_timesteps (lengths of episodes), episode_times (run-times)
+            id_ (int): The ID of this Runner (for distributed TF runs).
         """
-        self.agent = agent
-        self.environment = environment
-        self.repeat_actions = repeat_actions
+        super(Runner, self).__init__(agent, environment, repeat_actions, history)
 
-        self.episode = None  # the Agent's episode number
-        self.timestep = None  # the Agent's timestep
-        self.episode_timestep = None  # the timestep in the current episode
-
-        # lists of episode data (rewards, wall-times/timesteps)
-        self.start_time = None  # the time when an episode was started
-        self.episode_rewards = None  # list of accumulated episode rewards
-        self.episode_timesteps = None  # list of total timesteps taken in the episodes
-        self.episode_times = None  # list of durations for the episodes
-
-        self.reset(history)
-
-    def reset(self, history=None):
-        # If history is empty, use default values in history.get().
-        if not history:
-            history = dict()
-
-        self.episode_rewards = history.get('episode_rewards', list())
-        self.episode_timesteps = history.get('episode_timesteps', list())
-        self.episode_times = history.get('episode_times', list())
+        self.id = id_  # the worker's ID in a distributed run (default=0)
+        self.current_timestep = None  # the time step in the current episode
 
     def close(self):
         self.agent.close()
         self.environment.close()
 
-    def run(
-        self,
-        timesteps=None,
-        episodes=None,
-        max_episode_timesteps=None,
-        deterministic=False,
-        episode_finished=None
-    ):
+    # TODO: make average reward another possible criteria for runner-termination
+    def run(self, num_timesteps=None, num_episodes=None, max_episode_timesteps=None, deterministic=False,
+            episode_finished=None, summary_report=None, summary_interval=None, timesteps=None, episodes=None
+            ):
         """
-        Runs the agent on the environment.
-
         Args:
-            timesteps (int): Max. number of total timesteps to run (across episodes).
-            episodes (int): Max. number of episodes to run.
-            max_episode_timesteps (int): Max. number of timesteps per episode.
-            deterministic (bool): If true, pick actions from model without exploration/sampling.
-            episode_finished (callable): Function handler taking a `Runner` argument and returning a boolean indicating
-                whether to continue execution. For instance, useful for reporting intermediate performance or
-                integrating termination conditions.
+            timesteps (int): Deprecated; see num_timesteps.
+            episodes (int): Deprecated; see num_episodes.
         """
+
+        # deprecation warnings
+        if timesteps is not None:
+            num_timesteps = timesteps
+            warnings.warn("WARNING: `timesteps` parameter is deprecated, use `num_timesteps` instead.",
+                          category=DeprecationWarning)
+        if episodes is not None:
+            num_episodes = episodes
+            warnings.warn("WARNING: `episodes` parameter is deprecated, use `num_episodes` instead.",
+                          category=DeprecationWarning)
+
+        # figure out whether we are using the deprecated way of "episode_finished" reporting
+        old_episode_finished = False
+        if episode_finished is not None and len(signature(episode_finished).parameters) == 1:
+            old_episode_finished = True
 
         # Keep track of episode reward and episode length for statistics.
         self.start_time = time.time()
 
         self.agent.reset()
 
-        self.episode = self.agent.episode
-        if episodes is not None:
-            episodes += self.agent.episode
+        if num_episodes is not None:
+            num_episodes += self.agent.episode
 
-        self.timestep = self.agent.timestep
-        if timesteps is not None:
-            timesteps += self.agent.timestep
+        if num_timesteps is not None:
+            num_timesteps += self.agent.timestep
 
         # episode loop
         while True:
@@ -109,29 +89,26 @@ class Runner(object):
             self.agent.reset()
             state = self.environment.reset()
             episode_reward = 0
-            self.episode_timestep = 0
+            self.current_timestep = 0
 
-            # timestep (within episode) loop
+            # time step (within episode) loop
             while True:
                 action = self.agent.act(states=state, deterministic=deterministic)
 
-                if self.repeat_actions > 1:
-                    reward = 0
-                    for repeat in xrange(self.repeat_actions):
-                        state, terminal, step_reward = self.environment.execute(actions=action)
-                        reward += step_reward
-                        if terminal:
-                            break
-                else:
-                    state, terminal, reward = self.environment.execute(actions=action)
+                reward = 0
+                for repeat in xrange(self.repeat_actions):
+                    state, terminal, step_reward = self.environment.execute(actions=action)
+                    reward += step_reward
+                    if terminal:
+                        break
 
-                if max_episode_timesteps is not None and self.episode_timestep >= max_episode_timesteps:
+                if max_episode_timesteps is not None and self.current_timestep >= max_episode_timesteps:
                     terminal = True
 
                 self.agent.observe(terminal=terminal, reward=reward)
 
-                self.episode_timestep += 1
-                self.timestep += 1
+                self.current_timestep += 1
+                #self.global_timestep += 1
                 episode_reward += reward
 
                 if terminal or self.agent.should_stop():  # TODO: should_stop also terminate?
@@ -140,14 +117,34 @@ class Runner(object):
             # Update our episode stats.
             time_passed = time.time() - episode_start_time
             self.episode_rewards.append(episode_reward)
-            self.episode_timesteps.append(self.episode_timestep)
+            self.episode_timesteps.append(self.current_timestep)
             self.episode_times.append(time_passed)
-            self.episode += 1
+
+            # Update global counters.
+            #self.global_episode += 1
+            self.global_episode = self.agent.episode  # global value (across all agents)
+            self.global_timestep = self.agent.timestep  # global value (across all agents)
 
             # Check, whether we should stop this run.
-            if (episode_finished is not None and not episode_finished(self)) or \
-                    (episodes is not None and self.agent.episode >= episodes) or \
-                    (timesteps is not None and self.agent.timestep >= timesteps) or \
+            if episode_finished is not None:
+                # deprecated way (passing in only runner object):
+                if old_episode_finished:
+                    if not episode_finished(self):
+                        break
+                # new unified way (passing in BaseRunner AND some worker ID):
+                elif not episode_finished(self, self.id):
+                    break
+            if (num_episodes is not None and self.global_episode >= num_episodes) or \
+                    (num_timesteps is not None and self.global_timestep >= num_timesteps) or \
                     self.agent.should_stop():
-                # agent.episode / agent.timestep are globally updated
                 break
+
+    # keep backwards compatibility
+    @property
+    def episode_timestep(self):
+        return self.current_timestep
+
+
+# more descriptive alias for Runner class
+DistributedTFRunner = Runner
+SingleRunner = Runner

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -22,7 +22,7 @@ from tensorforce.execution.base_runner import BaseRunner
 import time
 from six.moves import xrange
 import warnings
-from inspect import getfullargspec
+from inspect import getargspec
 
 
 class Runner(BaseRunner):
@@ -68,7 +68,7 @@ class Runner(BaseRunner):
 
         # figure out whether we are using the deprecated way of "episode_finished" reporting
         old_episode_finished = False
-        if episode_finished is not None and len(getfullargspec(episode_finished).args) == 1:
+        if episode_finished is not None and len(getargspec(episode_finished).args) == 1:
             old_episode_finished = True
 
         # Keep track of episode reward and episode length for statistics.

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -22,7 +22,7 @@ from tensorforce.execution.base_runner import BaseRunner
 import time
 from six.moves import xrange
 import warnings
-from inspect import signature
+from inspect import getfullargspec
 
 
 class Runner(BaseRunner):
@@ -68,7 +68,7 @@ class Runner(BaseRunner):
 
         # figure out whether we are using the deprecated way of "episode_finished" reporting
         old_episode_finished = False
-        if episode_finished is not None and len(signature(episode_finished).parameters) == 1:
+        if episode_finished is not None and len(getfullargspec(episode_finished).args) == 1:
             old_episode_finished = True
 
         # Keep track of episode reward and episode length for statistics.

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -21,37 +21,44 @@ import time
 import threading
 from six.moves import xrange
 import warnings
+from inspect import signature
 
 from tensorforce import TensorForceError
+from tensorforce.execution.base_runner import BaseRunner
+from tensorforce.agents.learning_agent import LearningAgent
 
 
-class ThreadedRunner(object):
+class ThreadedRunner(BaseRunner):
     """
     Runner for non-realtime threaded execution of multiple agents.
     """
 
-    def __init__(self, agents, environments, repeat_actions=1, save_path=None, save_episodes=None, save_frequency=None,
-                 save_frequency_unit=None):
+    def __init__(self, agent, environment, repeat_actions=1, save_path=None, save_episodes=None, save_frequency=None,
+                 save_frequency_unit=None, agents=None, environments=None):
         """
         Initialize a ThreadedRunner object.
 
         Args:
-            agents (List[Agent]): List of Agent objects to use (one on each thread)
-            environments (List[Environment]): List of Environment objects to use (one for each agent)
-            repeat_actions (int): How many times the same given action will be repeated in subsequent calls to
-                Environment's `execute` method. Rewards collected in these calls are accumulated and reported
-                as a sum in the following call to Agent's `observe` method.
             save_path (str): Path where to save the shared model.
-            save_episodes (int): Every how many (global) episodes do we save the shared model?
+            save_episodes (int): Deprecated: Every how many (global) episodes do we save the shared model?
             save_frequency (int): The frequency with which to save the model (could be sec, steps, or episodes).
             save_frequency_unit (str): "s" (sec), "t" (timesteps), "e" (episodes)
+            agents (List[Agent]): Deprecated: List of Agent objects. Use `agent`, instead.
+            environments (List[Environment]): Deprecated: List of Environment objects. Use `environment`, instead.
         """
-        if len(agents) != len(environments):
+        if agents is not None:
+            warnings.warn("WARNING: `agents` parameter is deprecated, use `agent` instead.",
+                          category=DeprecationWarning)
+            agent = agents
+        if environments is not None:
+            warnings.warn("WARNING: `environments` parameter is deprecated, use `environments` instead.",
+                          category=DeprecationWarning)
+            environment = environments
+        super(ThreadedRunner, self).__init__(agent, environment, repeat_actions)
+
+        if len(agent) != len(environment):
             raise TensorForceError("Each agent must have its own environment. Got {a} agents and {e} environments.".
-                                   format(a=len(agents), e=len(environments)))
-        self.agents = agents
-        self.environments = environments
-        self.repeat_actions = repeat_actions
+                                   format(a=len(self.agent), e=len(self.environment)))
         self.save_path = save_path
         self.save_episodes = save_episodes
         if self.save_episodes is not None:
@@ -65,94 +72,31 @@ class ThreadedRunner(object):
             self.save_frequency_unit = save_frequency_unit
 
         # init some stats for the parallel runs
-        self.episode_rewards = None  # global episode-rewards collected by the different workers
-        self.episode_lengths = None  # global episode-lengths collected by the different workers
         self.episode_list_lock = threading.Lock()
-        self.start_time = None  # start time of a run (with many worker threads)
-        self.global_step = None  # global step counter (sum over all workers)
-        self.global_time = None  # global time counter (sec)
-        self.global_episode = None  # global episode counter (sum over all workers)
-        self.global_should_stop = False  # global stop-condition flag that each worker abides to (aborts if True)
+        self.should_stop = False  # stop-condition flag that each worker abides to (aborts if True)
+        self.time = None  # global time counter (sec)
 
-    def _run_single(self, thread_id, agent, environment, repeat_actions=1, max_episode_timesteps=-1,
-                    episode_finished=None):
+    def close(self):
+        self.agent[0].close()  # only close first agent as we just have one shared model
+        for e in self.environment:
+            e.close()
+
+    def run(self, num_episodes=-1, max_episode_timesteps=-1, episode_finished=None, summary_report=None,
+            summary_interval=0, num_timesteps=None, deterministic=False, episodes=None, max_timesteps=None):
         """
-        The target function for a thread, runs an agent and environment until signaled to stop.
-        Adds rewards to shared episode rewards list.
+        Executes this runner by starting all Agents in parallel (each one in one thread).
 
         Args:
-            max_episode_timesteps (int): Max. number of timesteps per episode. Use -1 or 0 for non-limited episodes.
-            episode_finished (callable): Function called after each episode that takes an episode summary spec and
-                returns False, if this single run should terminate after this episode.
-                Can be used e.g. to set a particular mean reward threshold.
-        """
-        episode = 1
-        # Run this single worker (episodes) as long as global count thresholds have not been reached.
-        while not self.global_should_stop:
-            state = environment.reset()
-            agent.reset()
-            episode_reward = 0
-
-            # timestep (within episode) loop
-            timestep = 0
-            while True:
-                action = agent.act(states=state)
-                if repeat_actions > 1:
-                    reward = 0
-                    for repeat in xrange(repeat_actions):
-                        state, terminal, step_reward = environment.execute(actions=action)
-                        reward += step_reward
-                        if terminal:
-                            break
-                else:
-                    state, terminal, reward = environment.execute(actions=action)
-
-                agent.observe(reward=reward, terminal=terminal)
-
-                timestep += 1
-                self.global_step += 1
-                episode_reward += reward
-
-                if terminal or timestep == max_episode_timesteps:
-                    break
-
-                # abort the episode (discard its results) when global says so
-                if self.global_should_stop:
-                    return
-
-            #agent.observe_episode_reward(episode_reward)
-
-            # Avoid race condition where order in episode_rewards won't match order in episode_lengths.
-            self.episode_list_lock.acquire()
-            self.episode_rewards.append(episode_reward)
-            self.episode_lengths.append(timestep)
-            self.episode_list_lock.release()
-
-            summary_data = {
-                "thread_id": thread_id,
-                "episode": episode,
-                "timestep": timestep,
-                "episode_reward": episode_reward
-            }
-            if episode_finished and not episode_finished(summary_data):
-                return
-
-            episode += 1
-            self.global_episode += 1
-
-    def run(self, episodes=-1, max_episode_timesteps=-1, episode_finished=None, summary_report=None,
-            summary_interval=0, max_timesteps=None):
+            episodes (int): Deprecated; see num_episodes.
+            max_timesteps (int): Deprecated; see max_episode_timesteps.
         """
 
-        Args:
-            episodes (int): Max. number of episodes to run in total (across all threads).
-            max_episode_timesteps (int): Max. number of timesteps per episode.
-            episode_finished (callable):
-            summary_report (callable): Function that produces a tensorboard summary update.
-            summary_interval (int):
-            max_timesteps (int): Deprecated; see max_episode_timesteps
-        """
-
+        # Renamed episodes into num_episodes to match BaseRunner's signature (fully backw. compatible).
+        if episodes is not None:
+            num_episodes = episodes
+            warnings.warn("WARNING: `episodes` parameter is deprecated, use `num_episodes` instead.",
+                          category=DeprecationWarning)
+        assert isinstance(num_episodes, int)
         # Renamed max_timesteps into max_episode_timesteps to match single Runner's signature (fully backw. compatible).
         if max_timesteps is not None:
             max_episode_timesteps = max_timesteps
@@ -160,21 +104,24 @@ class ThreadedRunner(object):
                           category=DeprecationWarning)
         assert isinstance(max_episode_timesteps, int)
 
-        # Save episode rewards and lengths for statistics.
-        self.episode_rewards = []
-        self.episode_lengths = []
+        if summary_report is not None:
+            warnings.warn("WARNING: `summary_report` parameter is deprecated, use `episode_finished` callback "
+                          "instead to generate summaries every n episodes.",
+                          category=DeprecationWarning)
+
+        self.reset()
 
         # Reset counts/stop-condition for this run.
-        self.global_step = 0
         self.global_episode = 1
-        self.global_should_stop = False
+        self.global_timestep = 0
+        self.should_stop = False
 
         # Create threads
-        threads = [threading.Thread(target=self._run_single, args=(t, self.agents[t], self.environments[t],),
-                                    kwargs={"repeat_actions": self.repeat_actions,
+        threads = [threading.Thread(target=self._run_single, args=(t, self.agent[t], self.environment[t],),
+                                    kwargs={"deterministic": deterministic,
                                             "max_episode_timesteps": max_episode_timesteps,
                                             "episode_finished": episode_finished})
-                   for t in range(len(self.agents))]
+                   for t in range(len(self.agent))]
 
         # Start threads
         self.start_time = time.time()
@@ -184,29 +131,128 @@ class ThreadedRunner(object):
         try:
             next_summary = 0
             next_save = 0
-            while self.global_episode < episodes or episodes == -1:
-                self.global_time = time.time()
-                if self.global_episode > next_summary:
+            while any([t.is_alive() for t in threads]) and self.global_episode < num_episodes or num_episodes == -1:
+                self.time = time.time()
+
+                # this is deprecated (but still supported) and should be covered by the `episode_finished` callable
+                if summary_report is not None and self.global_episode > next_summary:
                     summary_report(self)
                     next_summary += summary_interval
+
                 if self.save_path and self.save_frequency is not None:
                     if self.save_frequency_unit == "e" and self.global_episode > next_save:
                         print("Saving agent after episode {}".format(self.global_episode))
-                    elif self.save_frequency_unit == "s" and self.global_time > next_save:
+                    elif self.save_frequency_unit == "s" and self.time > next_save:
                         print("Saving agent after {} sec".format(self.save_frequency))
-                    elif self.global_step > next_save:
+                    elif self.global_timestep > next_save:
                         print("Saving agent after {} time steps".format(self.save_frequency))
-                    self.agents[0].save_model(self.save_path)
+                    self.agent[0].save_model(self.save_path)
                     next_save += self.save_frequency
                 time.sleep(1)
+
         except KeyboardInterrupt:
             print('Keyboard interrupt, sending stop command to threads')
 
-        self.global_should_stop = True
+        self.should_stop = True
 
         # Join threads
         [t.join() for t in threads]
         print('All threads stopped')
+
+    def _run_single(self, thread_id, agent, environment, deterministic=False,
+                    max_episode_timesteps=-1, episode_finished=None):
+        """
+        The target function for a thread, runs an agent and environment until signaled to stop.
+        Adds rewards to shared episode rewards list.
+
+        Args:
+            thread_id (int): The ID of the thread that's running this target function.
+            agent (Agent): The Agent object that this particular thread uses.
+            environment (Environment): The Environment object that this particular thread uses.
+            max_episode_timesteps (int): Max. number of timesteps per episode. Use -1 or 0 for non-limited episodes.
+            episode_finished (callable): Function called after each episode that takes an episode summary spec and
+                returns False, if this single run should terminate after this episode.
+                Can be used e.g. to set a particular mean reward threshold.
+        """
+
+        # figure out whether we are using the deprecated way of "episode_finished" reporting
+        old_episode_finished = False
+        if episode_finished is not None and len(signature(episode_finished).parameters) == 1:
+            old_episode_finished = True
+
+        episode = 1
+        # Run this single worker (episodes) as long as global count thresholds have not been reached.
+        while not self.should_stop:
+            state = environment.reset()
+            agent.reset()
+            episode_reward = 0
+
+            # time step (within episode) loop
+            time_step = 0
+            while True:
+                action = agent.act(states=state, deterministic=deterministic)
+                reward = 0
+                for repeat in xrange(self.repeat_actions):
+                    state, terminal, step_reward = environment.execute(actions=action)
+                    reward += step_reward
+                    if terminal:
+                        break
+
+                agent.observe(reward=reward, terminal=terminal)
+
+                time_step += 1
+                self.global_timestep += 1
+                episode_reward += reward
+
+                if terminal or time_step == max_episode_timesteps:
+                    break
+
+                # abort the episode (discard its results) when global says so
+                if self.should_stop:
+                    return
+
+            #agent.observe_episode_reward(episode_reward)
+
+            # Avoid race condition where order in episode_rewards won't match order in episode_timesteps.
+            self.episode_list_lock.acquire()
+            self.episode_rewards.append(episode_reward)
+            self.episode_timesteps.append(time_step)
+            self.episode_list_lock.release()
+
+            if episode_finished is not None:
+                # old way of calling episode_finished
+                if old_episode_finished:
+                    summary_data = {
+                        "thread_id": thread_id,
+                        "episode": episode,
+                        "timestep": time_step,
+                        "episode_reward": episode_reward
+                    }
+                    if not episode_finished(summary_data):
+                        return
+                # new way with BasicRunner (self) and thread-id
+                elif not episode_finished(self, thread_id):
+                    return
+
+            episode += 1
+            self.global_episode += 1
+
+    # backwards compatibility for deprecated properties (in case someone directly references these)
+    @property
+    def agents(self):
+        return self.agent
+
+    @property
+    def environments(self):
+        return self.environment
+
+    @property
+    def episode_lengths(self):
+        return self.episode_timesteps
+
+    @property
+    def global_step(self):
+        return self.global_timestep
 
 
 def WorkerAgentGenerator(agent_class):
@@ -222,6 +268,9 @@ def WorkerAgentGenerator(agent_class):
         def __init__(self, model=None, **kwargs):
             # set our model externally
             self.model = model
+            # be robust against `network_spec` coming in from kwargs even though this agent doesn't have one
+            if not isinstance(agent_class, LearningAgent):
+                kwargs.pop("network_spec")
             # call super c'tor (which will call initialize_model and assign self.model to the return value)
             super(WorkerAgent, self).__init__(**kwargs)
 
@@ -230,4 +279,32 @@ def WorkerAgentGenerator(agent_class):
             return self.model
 
     return WorkerAgent
+
+
+def clone_worker_agent(agent, factor, environment, network_spec, agent_config):
+    """
+    Clones a given Agent (`factor` times) and returns a list of the cloned Agents with the original Agent
+    in the first slot.
+
+    Args:
+        agent (Agent): The Agent object to clone.
+        factor (int): The length of the final list.
+        environment (Environment): The Environment to use for all cloned agents.
+        network_spec (LayeredNetwork): The Network to use (or None) for an Agent's Model.
+        agent_config (dict): A dict of Agent specifications passed into the Agent's c'tor as kwargs.
+    Returns:
+        The list with `factor` cloned agents (including the original one).
+    """
+    ret = [agent]
+    for i in xrange(factor - 1):
+        worker = WorkerAgentGenerator(type(agent))(
+            states_spec=environment.states,
+            actions_spec=environment.actions,
+            network_spec=network_spec,
+            model=agent.model,
+            **agent_config
+        )
+        ret.append(worker)
+
+    return ret
 

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -128,7 +128,7 @@ class ThreadedRunner(object):
         """
 
         Args:
-            episodes (List[Episode]):
+            episodes (int): Max. number of episodes to run in total (across all threads).
             max_episode_timesteps (int): Max. number of timesteps per episode.
             episode_finished (callable):
             summary_report (callable): Function that produces a tensorboard summary update.
@@ -199,7 +199,7 @@ def WorkerAgentGenerator(agent_class):
         def __init__(self, model=None, **kwargs):
             # set our model externally
             self.model = model
-            # call super c'tor (which will call initialize_model and assing self.model to the return value)
+            # call super c'tor (which will call initialize_model and assign self.model to the return value)
             super(WorkerAgent, self).__init__(**kwargs)
 
         def initialize_model(self):

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -146,7 +146,7 @@ class ThreadedRunner(BaseRunner):
                         print("Saving agent after episode {}".format(self.global_episode))
                     elif self.save_frequency_unit == "s" and self.time > next_save:
                         print("Saving agent after {} sec".format(self.save_frequency))
-                    elif self.global_timestep > next_save:
+                    elif self.save_frequency_unit == "t" and self.global_timestep > next_save:
                         print("Saving agent after {} time steps".format(self.save_frequency))
                     self.agent[0].save_model(self.save_path)
                     next_save += self.save_frequency

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -21,7 +21,7 @@ import time
 import threading
 from six.moves import xrange
 import warnings
-from inspect import getfullargspec
+from inspect import getargspec
 
 from tensorforce import TensorForceError
 from tensorforce.execution.base_runner import BaseRunner
@@ -177,7 +177,7 @@ class ThreadedRunner(BaseRunner):
 
         # figure out whether we are using the deprecated way of "episode_finished" reporting
         old_episode_finished = False
-        if episode_finished is not None and len(getfullargspec(episode_finished).args) == 1:
+        if episode_finished is not None and len(getargspec(episode_finished).args) == 1:
             old_episode_finished = True
 
         episode = 1

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -191,6 +191,7 @@ class ThreadedRunner(BaseRunner):
 
             # time step (within episode) loop
             time_step = 0
+            time_start = time.time()
             while True:
                 action = agent.act(states=state, deterministic=deterministic)
                 reward = 0
@@ -219,6 +220,7 @@ class ThreadedRunner(BaseRunner):
             self.episode_list_lock.acquire()
             self.episode_rewards.append(episode_reward)
             self.episode_timesteps.append(time_step)
+            self.episode_times.append(time.time() - time_start)
             self.episode_list_lock.release()
 
             if episode_finished is not None:

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -280,7 +280,7 @@ def WorkerAgentGenerator(agent_class):
             # set our model externally
             self.model = model
             # be robust against `network_spec` coming in from kwargs even though this agent doesn't have one
-            if not isinstance(agent_class, LearningAgent):
+            if not issubclass(agent_class, LearningAgent):
                 kwargs.pop("network_spec")
             # call super c'tor (which will call initialize_model and assign self.model to the return value)
             super(WorkerAgent, self).__init__(**kwargs)

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -22,10 +22,12 @@ import threading
 from six.moves import xrange
 import warnings
 from inspect import getargspec
+import importlib
 
 from tensorforce import TensorForceError
 from tensorforce.execution.base_runner import BaseRunner
 from tensorforce.agents.learning_agent import LearningAgent
+from tensorforce.agents import agents as AgentsDictionary
 
 
 class ThreadedRunner(BaseRunner):
@@ -259,6 +261,15 @@ def WorkerAgentGenerator(agent_class):
     """
     Worker Agent generator, receives an Agent class and creates a Worker Agent class that inherits from that Agent.
     """
+
+    # Support special case where class is given as type-string (AgentsDictionary) or class-name-string.
+    if isinstance(agent_class, str):
+        agent_class = AgentsDictionary.get(agent_class)
+        # Last resort: Class name given as string?
+        if not agent_class and agent_class.find('.') != -1:
+            module_name, function_name = agent_class.rsplit('.', 1)
+            module = importlib.import_module(module_name)
+            agent_class = getattr(module, function_name)
 
     class WorkerAgent(agent_class):
         """

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -21,7 +21,7 @@ import time
 import threading
 from six.moves import xrange
 import warnings
-from inspect import signature
+from inspect import getfullargspec
 
 from tensorforce import TensorForceError
 from tensorforce.execution.base_runner import BaseRunner
@@ -177,7 +177,7 @@ class ThreadedRunner(BaseRunner):
 
         # figure out whether we are using the deprecated way of "episode_finished" reporting
         old_episode_finished = False
-        if episode_finished is not None and len(signature(episode_finished).parameters) == 1:
+        if episode_finished is not None and len(getfullargspec(episode_finished).args) == 1:
             old_episode_finished = True
 
         episode = 1

--- a/tensorforce/tests/base_agent_test.py
+++ b/tensorforce/tests/base_agent_test.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from tensorforce.tests.base_test import BaseTest
+from tensorforce.tests.base_test import BaseTest, RunMode
 from tensorforce.core.networks import Dense, LayerBasedNetwork
 from tensorforce.environments.minimal_test import MinimalTest
 
@@ -38,8 +38,9 @@ class BaseAgentTest(BaseTest):
     exclude_bounded = False
     exclude_multi = False
     exclude_lstm = False
-    # Run-type flag
-    run_type = "single"  # normally run in single mode (possible also: 'multi-threaded', 'distributed')
+    # Run-type flags
+    run_mode = RunMode.SINGLE  # normally run in single mode (possible also: 'multi-threaded', 'distributed')
+    num_parallel_workers = 5  # the number of parallel workers if run_mode is not SINGLE
 
     def test_bool(self):
         """
@@ -54,13 +55,16 @@ class BaseAgentTest(BaseTest):
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
-        self.base_test_pass(
-            name='bool',
-            environment=environment,
-            network_spec=network_spec,
-            multithreaded=(self.__class__.run_type == "multi-threaded"),
-            **self.__class__.config
-        )
+        for mode in RunMode:
+            if self.__class__.run_mode & mode.value:
+                self.base_test_pass(
+                    name='bool',
+                    environment=environment,
+                    network_spec=network_spec,
+                    run_mode=mode.value,
+                    num_workers=self.__class__.num_parallel_workers,
+                    **self.__class__.config
+                )
 
     def test_int(self):
         """
@@ -75,13 +79,16 @@ class BaseAgentTest(BaseTest):
             dict(type='dense', size=32)
         ]
 
-        self.base_test_pass(
-            name='int',
-            environment=environment,
-            network_spec=network_spec,
-            multithreaded=(self.__class__.run_type == "multi-threaded"),
-            **self.__class__.config
-        )
+        for mode in RunMode:
+            if self.__class__.run_mode & mode.value:
+                self.base_test_pass(
+                    name='int',
+                    environment=environment,
+                    network_spec=network_spec,
+                    run_mode=mode.value,
+                    num_workers=self.__class__.num_parallel_workers,
+                    **self.__class__.config
+                )
 
     def test_float(self):
         """
@@ -95,13 +102,16 @@ class BaseAgentTest(BaseTest):
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
-        self.base_test_pass(
-            name='float',
-            environment=environment,
-            network_spec=network_spec,
-            multithreaded=(self.__class__.run_type == "multi-threaded"),
-            **self.__class__.config
-        )
+        for mode in RunMode:
+            if self.__class__.run_mode & mode.value:
+                self.base_test_pass(
+                    name='float',
+                    environment=environment,
+                    network_spec=network_spec,
+                    run_mode=mode.value,
+                    num_workers=self.__class__.num_parallel_workers,
+                    **self.__class__.config
+                )
 
     def test_bounded_float(self):
         """
@@ -115,13 +125,16 @@ class BaseAgentTest(BaseTest):
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
-        self.base_test_pass(
-            name='bounded',
-            environment=environment,
-            network_spec=network_spec,
-            multithreaded=(self.__class__.run_type == "multi-threaded"),
-            **self.__class__.config
-        )
+        for mode in RunMode:
+            if self.__class__.run_mode & mode.value:
+                self.base_test_pass(
+                    name='bounded',
+                    environment=environment,
+                    network_spec=network_spec,
+                    run_mode=mode.value,
+                    num_workers=self.__class__.num_parallel_workers,
+                    **self.__class__.config
+                )
 
     def test_multi(self):
         """
@@ -206,21 +219,27 @@ class BaseAgentTest(BaseTest):
         environment = MinimalTest(specification=specification)
 
         if self.__class__.multi_config is None:
-            self.base_test_run(
-                name='multi',
-                environment=environment,
-                network_spec=CustomNetwork,
-                multithreaded=(not self.__class__.run_type == "multi-threaded"),
-                **self.__class__.config
-            )
+            for mode in RunMode:
+                if self.__class__.run_mode & mode.value:
+                    self.base_test_run(
+                        name='multi',
+                        environment=environment,
+                        network_spec=CustomNetwork,
+                        run_mode=mode.value,
+                        num_workers=self.__class__.num_parallel_workers,
+                        **self.__class__.config
+                    )
         else:
-            self.base_test_run(
-                name='multi',
-                environment=environment,
-                network_spec=CustomNetwork,
-                multithreaded=(self.__class__.run_type == "multi-threaded"),
-                **self.__class__.multi_config
-            )
+            for mode in RunMode:
+                if self.__class__.run_mode & mode.value:
+                    self.base_test_run(
+                        name='multi',
+                        environment=environment,
+                        network_spec=CustomNetwork,
+                        run_mode=mode.value,
+                        num_workers=self.__class__.num_parallel_workers,
+                        **self.__class__.multi_config
+                    )
 
     def test_lstm(self):
         """
@@ -236,10 +255,13 @@ class BaseAgentTest(BaseTest):
             dict(type='internal_lstm', size=32)
         ]
 
-        self.base_test_pass(
-            name='lstm',
-            environment=environment,
-            network_spec=network_spec,
-            multithreaded=(self.__class__.run_type == "multi-threaded"),
-            **self.__class__.config
-        )
+        for mode in RunMode:
+            if self.__class__.run_mode & mode.value:
+                self.base_test_pass(
+                    name='lstm',
+                    environment=environment,
+                    network_spec=network_spec,
+                    run_mode=mode.value,
+                    num_workers=self.__class__.num_parallel_workers,
+                    **self.__class__.config
+                )

--- a/tensorforce/tests/base_agent_test.py
+++ b/tensorforce/tests/base_agent_test.py
@@ -38,6 +38,8 @@ class BaseAgentTest(BaseTest):
     exclude_bounded = False
     exclude_multi = False
     exclude_lstm = False
+    # Run-type flag
+    run_type = "single"  # normally run in single mode (possible also: 'multi-threaded', 'distributed')
 
     def test_bool(self):
         """
@@ -56,6 +58,7 @@ class BaseAgentTest(BaseTest):
             name='bool',
             environment=environment,
             network_spec=network_spec,
+            multithreaded=(self.__class__.run_type == "multi-threaded"),
             **self.__class__.config
         )
 
@@ -76,6 +79,7 @@ class BaseAgentTest(BaseTest):
             name='int',
             environment=environment,
             network_spec=network_spec,
+            multithreaded=(self.__class__.run_type == "multi-threaded"),
             **self.__class__.config
         )
 
@@ -95,6 +99,7 @@ class BaseAgentTest(BaseTest):
             name='float',
             environment=environment,
             network_spec=network_spec,
+            multithreaded=(self.__class__.run_type == "multi-threaded"),
             **self.__class__.config
         )
 
@@ -114,6 +119,7 @@ class BaseAgentTest(BaseTest):
             name='bounded',
             environment=environment,
             network_spec=network_spec,
+            multithreaded=(self.__class__.run_type == "multi-threaded"),
             **self.__class__.config
         )
 
@@ -204,6 +210,7 @@ class BaseAgentTest(BaseTest):
                 name='multi',
                 environment=environment,
                 network_spec=CustomNetwork,
+                multithreaded=(not self.__class__.run_type == "multi-threaded"),
                 **self.__class__.config
             )
         else:
@@ -211,6 +218,7 @@ class BaseAgentTest(BaseTest):
                 name='multi',
                 environment=environment,
                 network_spec=CustomNetwork,
+                multithreaded=(self.__class__.run_type == "multi-threaded"),
                 **self.__class__.multi_config
             )
 
@@ -232,5 +240,6 @@ class BaseAgentTest(BaseTest):
             name='lstm',
             environment=environment,
             network_spec=network_spec,
+            multithreaded=(self.__class__.run_type == "multi-threaded"),
             **self.__class__.config
         )

--- a/tensorforce/tests/base_test.py
+++ b/tensorforce/tests/base_test.py
@@ -21,9 +21,10 @@ import logging
 
 from six.moves import xrange
 import sys
+import copy
 
-from tensorforce.execution import Runner
-
+from tensorforce.execution import SingleRunner, ThreadedRunner
+from tensorforce.execution.threaded_runner import clone_worker_agent
 
 logging.getLogger('tensorflow').disabled = True
 
@@ -47,13 +48,21 @@ class BaseTest(object):
     def base_test_pass(self, name, environment, network_spec, **kwargs):
         """
         Basic test loop, requires an Agent to achieve a certain performance on an environment.
+
+        Args:
+            name (str): The name of the test.
+            environment (Environment): The Environment object to use for the test.
+            network_spec (LayerBasedNetwork): The Network to use for the agent's model.
+            kwargs (any):
+                'multithreaded'=True if this run should be made using the ThreadedRunner.
         """
         sys.stdout.write('\n{} ({}):'.format(self.__class__.agent.__name__, name))
         sys.stdout.flush()
 
+        threaded = kwargs.pop("multithreaded", False)
+
         passed = 0
         for _ in xrange(3):
-
             if self.__class__.requires_network:
                 agent = self.__class__.agent(
                     states_spec=environment.states,
@@ -68,11 +77,19 @@ class BaseTest(object):
                     **kwargs
                 )
 
-            runner = Runner(agent=agent, environment=environment)
+            if threaded:
+                num_workers = 5
+                agents = clone_worker_agent(agent, num_workers, environment,
+                                                network_spec if self.__class__.requires_network else None, kwargs)
+                environments = [environment]
+                for _ in range(num_workers - 1):
+                    environments.append(copy.deepcopy(environment))
+                runner = ThreadedRunner(agent=agents, environment=environments)
+            else:
+                runner = SingleRunner(agent=agent, environment=environment)
+                self.pre_run(agent=agent, environment=environment)
 
-            self.pre_run(agent=agent, environment=environment)
-
-            def episode_finished(r):
+            def episode_finished(r, worker_id=0):
                 episodes_passed = [
                     rw / ln >= self.__class__.pass_threshold
                     for rw, ln in zip(r.episode_rewards[-100:], r.episode_timesteps[-100:])
@@ -98,10 +115,19 @@ class BaseTest(object):
         """
         Run test, tests whether algorithm can run and update without compilation errors,
         not whether it passes.
+
+        Args:
+            name (str): The name of the test.
+            environment (Environment): The Environment object to use for the test.
+            network_spec (LayerBasedNetwork): The Network to use for the agent's model.
+            kwargs (any):
+                'multithreaded'=True if this run should be made using the ThreadedRunner.
         """
 
         sys.stdout.write('\n{} ({}):'.format(self.__class__.agent.__name__, name))
         sys.stdout.flush()
+
+        threaded = kwargs.pop("multithreaded", False)
 
         if self.__class__.requires_network:
             agent = self.__class__.agent(
@@ -117,19 +143,28 @@ class BaseTest(object):
                 **kwargs
             )
 
-        runner = Runner(agent=agent, environment=environment)
+        if threaded:
+            num_workers = 5
+            agents = duplicate_worker_agent(agent, num_workers, environment,
+                                            network_spec if self.__class__.requires_network else None, kwargs)
+            environments = [environment]
+            for _ in range(num_workers - 1):
+                environments.append(copy.deepcopy(environment))
+            runner = ThreadedRunner(agent=agents, environment=environments)
+        else:
+            runner = SingleRunner(agent=agent, environment=environment)
+            self.pre_run(agent=agent, environment=environment)
 
-        self.pre_run(agent=agent, environment=environment)
-
-        def episode_finished(r):
+        def episode_finished(r, worker_id=0):
             episodes_passed = [
                 rw / ln >= self.__class__.pass_threshold
                 for rw, ln in zip(r.episode_rewards[-100:], r.episode_timesteps[-100:])
             ]
             return r.episode < 100 or not all(episodes_passed)
 
-        runner.run(episodes=100, deterministic=self.__class__.deterministic, episode_finished=episode_finished)
+        runner.run(num_episodes=100, deterministic=self.__class__.deterministic, episode_finished=episode_finished)
         runner.close()
 
         sys.stdout.write('==> {} ran\n'.format(1))
         sys.stdout.flush()
+

--- a/tensorforce/tests/base_test.py
+++ b/tensorforce/tests/base_test.py
@@ -90,8 +90,7 @@ class BaseTest(object):
                 )
 
             if run_mode == RunMode.MULTI_THREADED:
-                agents = clone_worker_agent(agent, num_workers, environment,
-                                            network_spec if self.__class__.requires_network else None, kwargs)
+                agents = clone_worker_agent(agent, num_workers, environment, network_spec, kwargs)
                 environments = [environment]
                 for _ in range(num_workers - 1):
                     environments.append(copy.deepcopy(environment))
@@ -155,8 +154,7 @@ class BaseTest(object):
             )
 
         if run_mode == RunMode.MULTI_THREADED:
-            agents = clone_worker_agent(agent, num_workers, environment,
-                                        network_spec if self.__class__.requires_network else None, kwargs)
+            agents = clone_worker_agent(agent, num_workers, environment, network_spec, kwargs)
             environments = [environment]
             for _ in range(num_workers - 1):
                 environments.append(copy.deepcopy(environment))

--- a/tensorforce/tests/test_constant_agent.py
+++ b/tensorforce/tests/test_constant_agent.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 from __future__ import division
 
 import unittest
-from tensorforce.tests.base_agent_test import BaseAgentTest
+from tensorforce.tests.base_agent_test import BaseAgentTest, RunMode
 from tensorforce.agents import ConstantAgent
 
 
@@ -43,4 +43,4 @@ class TestConstantAgent(BaseAgentTest, unittest.TestCase):
     exclude_multi = True
     exclude_lstm = True
 
-    run_type = "multi-threaded"
+    run_mode = RunMode.SINGLE | RunMode.MULTI_THREADED

--- a/tensorforce/tests/test_constant_agent.py
+++ b/tensorforce/tests/test_constant_agent.py
@@ -42,3 +42,5 @@ class TestConstantAgent(BaseAgentTest, unittest.TestCase):
     exclude_bounded = True
     exclude_multi = True
     exclude_lstm = True
+
+    run_type = "multi-threaded"

--- a/tensorforce/tests/test_ppo_agent.py
+++ b/tensorforce/tests/test_ppo_agent.py
@@ -19,7 +19,7 @@ from __future__ import division
 
 import unittest
 
-from tensorforce.tests.base_agent_test import BaseAgentTest
+from tensorforce.tests.base_agent_test import BaseAgentTest, RunMode
 from tensorforce.agents import PPOAgent
 
 
@@ -38,3 +38,5 @@ class TestPPOAgent(BaseAgentTest, unittest.TestCase):
             learning_rate=0.001
         )
     )
+
+    run_mode = RunMode.SINGLE | RunMode.MULTI_THREADED

--- a/tensorforce/tests/test_random_agent.py
+++ b/tensorforce/tests/test_random_agent.py
@@ -35,3 +35,5 @@ class TestRandomAgent(BaseAgentTest, unittest.TestCase):
 
     # Not using a network so no point in testing LSTM
     exclude_lstm = True
+
+    run_type = "multi-threaded"

--- a/tensorforce/tests/test_random_agent.py
+++ b/tensorforce/tests/test_random_agent.py
@@ -19,7 +19,7 @@ from __future__ import division
 
 import unittest
 
-from tensorforce.tests.base_agent_test import BaseAgentTest
+from tensorforce.tests.base_agent_test import BaseAgentTest, RunMode
 from tensorforce.agents import RandomAgent
 
 
@@ -36,4 +36,4 @@ class TestRandomAgent(BaseAgentTest, unittest.TestCase):
     # Not using a network so no point in testing LSTM
     exclude_lstm = True
 
-    run_type = "multi-threaded"
+    run_mode = RunMode.SINGLE | RunMode.MULTI_THREADED

--- a/tensorforce/util.py
+++ b/tensorforce/util.py
@@ -160,7 +160,7 @@ def get_object(obj, predefined_objects=None, default_object=None, kwargs=None):
             obj = getattr(module, function_name)
         else:
             predef_obj_keys = list(predefined_objects.keys())
-            raise TensorForceError("Error: object {} not found in predefined objects: {}".format(obj,predef_obj_keys))
+            raise TensorForceError("Error: object {} not found in predefined objects: {}".format(obj, predef_obj_keys))
     elif callable(obj):
         pass
     elif default_object is not None:


### PR DESCRIPTION
Introduced BaseRunner class.
Restructured existing Runner classes (Runner and ThreadedRunner) to both inherit from BaseRunner.
Unified the interfaces used to control these classes and to handle per-episode and per-n-episode reporting.
Added multi-threaded testing to random and constant agent tests (configurable for all agents via run_type flag).
Removed some tf deprecation WARNINGS.