### PR TITLE
Fixed: steps per second calculation maze explorer

### DIFF
--- a/examples/maze_explorer.py
+++ b/examples/maze_explorer.py
@@ -108,7 +108,7 @@ def main():
 
     def episode_finished(r):
         if r.episode % report_episodes == 0:
-            sps = r.total_timesteps / (time.time() - r.start_time)
+            sps = r.timestep / (time.time() - r.start_time)
             logger.info("Finished episode {ep} after {ts} timesteps. Steps Per Second {sps}".format(ep=r.episode, ts=r.timestep, sps=sps))
             logger.info("Episode reward: {}".format(r.episode_rewards[-1]))
             logger.info("Average of last 500 rewards: {}".format(sum(r.episode_rewards[-500:]) / 500))


### PR DESCRIPTION
Hello, I hope I am following the right procedure here. This is my first pull request. This fixes the following error:
```AttributeError: 'Runner' object has no attribute 'total_timesteps'```
Also the maze explorer example only works in mode 1. Mode 0 throws another error. I will have a look at this.