### PR TITLE
Sequence and running_standardize preprocessors

### DIFF
--- a/examples/unreal_engine.py
+++ b/examples/unreal_engine.py
@@ -141,11 +141,11 @@ def main():
 
     logger.info("Starting {agent} for Environment '{env}'".format(agent=agent, env=environment))
 
-    def episode_finished(r):
+    def episode_finished(r, id_):
         if r.episode % report_episodes == 0:
-            steps_per_second = r.timestep / (time.time() - r.start_time)
-            logger.info("Finished episode {} after {} timesteps. Steps Per Second {}".format(
-                r.agent.episode, r.episode_timestep, steps_per_second
+            steps_per_second = r.global_timestep / (time.time() - r.start_time)
+            logger.info("Finished episode {} after {} timesteps. SPS={}".format(
+                r.global_episode, r.episode_timestep, steps_per_second
             ))
             logger.info("Episode reward: {}".format(r.episode_rewards[-1]))
             logger.info("Average of last 500 rewards: {}".format(sum(r.episode_rewards[-500:]) /

--- a/tensorforce/agents/agent.py
+++ b/tensorforce/agents/agent.py
@@ -47,11 +47,11 @@ class Agent(object):
         Initializes the reinforcement learning agent.
 
         Args:
-            states_spec (dict): Dict containing at least one state-component definition. In the case of a single state
+            states (dict): Dict containing at least one state-component definition. In the case of a single state
                 space component, the keys `shape` and `type` are necessary (e.g. a 3D float-box with shape [3,3,3]).
                 For multiple state components, pass a dict of dicts where each component is a dict itself with a unique
                 name as its key (e.g. {cam: {shape: [84,84], type=int}, health: {shape=(), type=float}}).
-            actions_spec (dict): Dict containing at least one action-component definition.
+            actions (dict): Dict containing at least one action-component definition.
                 Action components have types and either `num_actions` for discrete actions or a `shape`
                 for continuous actions.
                 Consult documentation and tests for more.
@@ -156,10 +156,6 @@ class Agent(object):
         """
         self.episode, self.timestep, self.next_internals = self.model.reset()
         self.current_internals = self.next_internals
-
-        # TODO have to call preprocessing reset in model
-        # for preprocessing in self.preprocessing.values():
-        #     preprocessing.reset()
 
     def act(self, states, deterministic=False, fetch_tensors=None):
         """

--- a/tensorforce/agents/learning_agent.py
+++ b/tensorforce/agents/learning_agent.py
@@ -57,30 +57,30 @@ class LearningAgent(Agent):
         Initializes the learning agent.
 
         Args:
-            summary_spec: Dict specifying summarizer for TensorBoard. Requires a 'directory' to store summarizer, `steps`
+            summarizer: Dict specifying summarizer for TensorBoard. Requires a 'directory' to store summarizer, `steps`
                 or `seconds` to specify how often to save summarizer, and a list of `labels` to indicate which values
                 to export, e.g. `losses`, `variables`. Consult neural network class and model for all available labels.
-            network_spec: List of layers specifying a neural network via layer types, sizes and optional arguments
+            network: List of layers specifying a neural network via layer types, sizes and optional arguments
                 such as activation or regularisation. Full examples are in the examples/configs folder.
             discount (float): The reward discount factor.
             device: Device string specifying model device.
             session_config: optional tf.ConfigProto with additional desired session configurations
-            saver_spec: Dict specifying automated saving. Use `directory` to specify where checkpoints are saved. Use
+            saver: Dict specifying automated saving. Use `directory` to specify where checkpoints are saved. Use
                 either `seconds` or `steps` to specify how often the model should be saved. The `load` flag specifies
                 if a model is initially loaded (set to True) from a file `file`.
-            distributed_spec: Dict specifying distributed functionality. Use `parameter_server` and `replica_model`
+            distributed: Dict specifying distributed functionality. Use `parameter_server` and `replica_model`
                 Boolean flags to indicate workers and parameter servers. Use a `cluster_spec` key to pass a TensorFlow
                 cluster spec.
             optimizer: Dict specifying optimizer type and its optional parameters, typically a `learning_rate`.
                 Available optimizer types include standard TensorFlow optimizers, `natural_gradient`,
                 and `evolutionary`. Consult the optimizer test or example configurations for more.
             variable_noise: Experimental optional parameter specifying variable noise (NoisyNet).
-            states_preprocessing_spec: Optional list of states preprocessors to apply to state
+            states_preprocessing: Optional list of states preprocessors to apply to state
                 (e.g. `image_resize`, `greyscale`).
-            explorations_spec: Optional dict specifying action exploration type (epsilon greedy
+            actions_exploration: Optional dict specifying action exploration type (epsilon greedy
                 or Gaussian noise).
-            reward_preprocessing_spec: Optional dict specifying reward preprocessing.
-            distributions_spec: Optional dict specifying action distributions to override default distribution choices.
+            reward_preprocessing: Optional dict specifying reward preprocessing.
+            distributions: Optional dict specifying action distributions to override default distribution choices.
                 Must match action names.
             entropy_regularization: Optional positive float specifying an entropy regularization value.
         """

--- a/tensorforce/core/preprocessing/preprocessor.py
+++ b/tensorforce/core/preprocessing/preprocessor.py
@@ -20,7 +20,14 @@ import tensorflow as tf
 
 
 class Preprocessor(object):
+    """
+    A Preprocessor is an object used to map input state signals to some RL-model
+    to some "preprocessed state signals". For example: If the input state is an RGB image of 84x84px (3 color
+    channels; 84x84x3 tensor), a preprocessor could make this image a grayscale 84x84x1 tensor, instead.
 
+    Each preprocessor is fully integrated into the model's graph, has its own scope and owns some
+    variables that live under that scope in the graph.
+    """
     def __init__(self, shape, scope='preprocessor', summary_labels=None):
         self.shape = shape
         self.summary_labels = set(summary_labels or ())
@@ -38,18 +45,28 @@ class Preprocessor(object):
             func_=self.tf_process,
             custom_getter_=custom_getter
         )
+        self.reset = tf.make_template(
+            name_=(scope + '/reset'),
+            func_=self.tf_reset,
+            custom_getter_=custom_getter
+        )
 
-    def reset(self):
+    def tf_reset(self):
+        """
+        Resets this preprocessor to some initial state. This method is called whenever an episode ends.
+        This could be useful if the preprocessor stores certain episode-sequence information to do the processing
+        and this information has to be reset after the episode terminates.
+        """
         pass
 
     def tf_process(self, tensor):
         """
-        Process state.
+        Process state (tensor).
 
         Args:
-            tensor: tensor to process.
+            tensor (tf.Tensor): The Tensor to process.
 
-        Returns: processed tensor.
+        Returns: The pre-processed Tensor.
         """
         return tensor
 
@@ -58,9 +75,9 @@ class Preprocessor(object):
         Shape of preprocessed state given original shape.
 
         Args:
-            shape: original shape.
+            shape (tuple): The original (unprocessed) shape.
 
-        Returns: processed tensor shape
+        Returns: The processed tensor shape.
         """
         return shape
 

--- a/tensorforce/core/preprocessing/preprocessor_stack.py
+++ b/tensorforce/core/preprocessing/preprocessor_stack.py
@@ -23,13 +23,24 @@ import tensorforce.core.preprocessing
 
 
 class PreprocessorStack(object):
-
+    """
+    A class to handle many Preprocessor objects applied in a sequence to some state. For example: An image
+    tensor as state signal could be re-sized first, then grayscaled, then normalized.
+    """
     def __init__(self):
         self.preprocessors = list()
 
     def reset(self):
+        """
+        Calls `reset` on all our Preprocessor objects.
+
+        Returns:
+            A list of tensors to be fetched.
+        """
+        fetches = []
         for processor in self.preprocessors:
-            processor.reset()
+            fetches.extend(processor.reset() or [])
+        return fetches
 
     def process(self, tensor):
         """

--- a/tensorforce/core/preprocessing/running_standardize.py
+++ b/tensorforce/core/preprocessing/running_standardize.py
@@ -37,12 +37,13 @@ class RunningStandardize(Preprocessor):
         summary_labels=()
     ):
         self.reset_after_batch = reset_after_batch
+        # The op that resets our stats variables.
+        self.reset_op = None
         super(RunningStandardize, self).__init__(shape=shape, scope=scope, summary_labels=summary_labels)
 
-    def reset(self):
+    def tf_reset(self):
         if self.reset_after_batch:
-            # TODO is this being called as a tf op?
-            pass
+            return [self.reset_op]
 
     def tf_process(self, tensor):
         count = tf.get_variable(
@@ -65,6 +66,7 @@ class RunningStandardize(Preprocessor):
             initializer=tf.zeros_initializer(),
             trainable=False
         )
+        self.reset_op = tf.variables_initializer([count, mean_estimate, variance_sum_estimate], name='reset-op')
 
         assignment = tf.assign_add(ref=count, value=1.0)
 

--- a/tensorforce/core/preprocessing/sequence.py
+++ b/tensorforce/core/preprocessing/sequence.py
@@ -26,23 +26,25 @@ from tensorforce.core.preprocessing import Preprocessor
 class Sequence(Preprocessor):
     """
     Concatenate `length` state vectors. Example: Used in Atari
-    problems to create the Markov property.
+    problems to create the Markov property (velocity of game objects as they move across the screen).
     """
 
-    def __init__(
-        self,
-        shape,
-        length=2,
-        scope='sequence',
-        summary_labels=()
-    ):
+    def __init__(self, shape, length=2, scope='sequence', summary_labels=()):
+        """
+        Args:
+            length (int): The number of states to concatenate. In the beginning, when no previous state is available,
+                concatenate the given first state with itself `length` times.
+        """
+        # raise TensorForceError("The sequence preprocessor is temporarily broken; use version 0.3.2 if required.")
         self.length = length
+        ## The index tensor pointing to the previous location in the single-state buffer.
+        #self.index = None
+        # The that resets index back to -1.
+        self.reset_op = None
         super(Sequence, self).__init__(shape=shape, scope=scope, summary_labels=summary_labels)
 
-    def reset(self):
-        #TODO fix
-        # self.index = -1 !!!!!!!!!!!!
-        pass
+    def tf_reset(self):
+        return [self.reset_op]
 
     def tf_process(self, tensor):
         # or just always the same?
@@ -60,6 +62,7 @@ class Sequence(Preprocessor):
             initializer=-1,
             trainable=False
         )
+        self.reset_op = tf.variables_initializer([index], name='reset-op')
 
         def first_run():
             fill_buffer = (self.length,) + tuple(1 for _ in range(util.rank(tensor) - 1))

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -85,9 +85,13 @@ class Runner(BaseRunner):
         # episode loop
         while True:
             episode_start_time = time.time()
-
-            self.agent.reset()
             state = self.environment.reset()
+            self.agent.reset()
+
+            # Update global counters.
+            self.global_episode = self.agent.episode  # global value (across all agents)
+            self.global_timestep = self.agent.timestep  # global value (across all agents)
+
             episode_reward = 0
             self.current_timestep = 0
 
@@ -107,8 +111,8 @@ class Runner(BaseRunner):
 
                 self.agent.observe(terminal=terminal, reward=reward)
 
+                self.global_timestep += 1
                 self.current_timestep += 1
-                #self.global_timestep += 1
                 episode_reward += reward
 
                 if terminal or self.agent.should_stop():  # TODO: should_stop also terminate?
@@ -120,10 +124,7 @@ class Runner(BaseRunner):
             self.episode_timesteps.append(self.current_timestep)
             self.episode_times.append(time_passed)
 
-            # Update global counters.
-            #self.global_episode += 1
-            self.global_episode = self.agent.episode  # global value (across all agents)
-            self.global_timestep = self.agent.timestep  # global value (across all agents)
+            self.global_episode += 1
 
             # Check, whether we should stop this run.
             if episode_finished is not None:

--- a/tensorforce/tests/base_agent_test.py
+++ b/tensorforce/tests/base_agent_test.py
@@ -51,7 +51,7 @@ class BaseAgentTest(BaseTest):
 
         environment = MinimalTest(specification={'bool': ()})
 
-        network_spec = [
+        network = [
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
@@ -60,7 +60,7 @@ class BaseAgentTest(BaseTest):
                 self.base_test_pass(
                     name='bool',
                     environment=environment,
-                    network_spec=network_spec,
+                    network=network,
                     run_mode=mode.value,
                     num_workers=self.__class__.num_parallel_workers,
                     **self.__class__.config
@@ -74,7 +74,7 @@ class BaseAgentTest(BaseTest):
             return
 
         environment = MinimalTest(specification={'int': ()})
-        network_spec = [
+        network = [
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
@@ -84,7 +84,7 @@ class BaseAgentTest(BaseTest):
                 self.base_test_pass(
                     name='int',
                     environment=environment,
-                    network_spec=network_spec,
+                    network=network,
                     run_mode=mode.value,
                     num_workers=self.__class__.num_parallel_workers,
                     **self.__class__.config
@@ -98,7 +98,7 @@ class BaseAgentTest(BaseTest):
             return
 
         environment = MinimalTest(specification={'float': ()})
-        network_spec = [
+        network = [
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
@@ -107,7 +107,7 @@ class BaseAgentTest(BaseTest):
                 self.base_test_pass(
                     name='float',
                     environment=environment,
-                    network_spec=network_spec,
+                    network=network,
                     run_mode=mode.value,
                     num_workers=self.__class__.num_parallel_workers,
                     **self.__class__.config
@@ -121,7 +121,7 @@ class BaseAgentTest(BaseTest):
             return
 
         environment = MinimalTest(specification={'bounded': ()})
-        network_spec = [
+        network = [
             dict(type='dense', size=32),
             dict(type='dense', size=32)
         ]
@@ -130,7 +130,7 @@ class BaseAgentTest(BaseTest):
                 self.base_test_pass(
                     name='bounded',
                     environment=environment,
-                    network_spec=network_spec,
+                    network=network,
                     run_mode=mode.value,
                     num_workers=self.__class__.num_parallel_workers,
                     **self.__class__.config
@@ -227,7 +227,7 @@ class BaseAgentTest(BaseTest):
                     self.base_test_run(
                         name='multi',
                         environment=environment,
-                        network_spec=CustomNetwork,
+                        network=CustomNetwork,
                         run_mode=mode.value,
                         num_workers=self.__class__.num_parallel_workers,
                         **self.__class__.config
@@ -238,7 +238,7 @@ class BaseAgentTest(BaseTest):
                     self.base_test_run(
                         name='multi',
                         environment=environment,
-                        network_spec=CustomNetwork,
+                        network=CustomNetwork,
                         run_mode=mode.value,
                         num_workers=self.__class__.num_parallel_workers,
                         **self.__class__.multi_config
@@ -252,7 +252,7 @@ class BaseAgentTest(BaseTest):
             return
 
         environment = MinimalTest(specification={'int': ()})
-        network_spec = [
+        network = [
             dict(type='dense', size=32),
             dict(type='dense', size=32),
             dict(type='internal_lstm', size=32)
@@ -263,7 +263,7 @@ class BaseAgentTest(BaseTest):
                 self.base_test_pass(
                     name='lstm',
                     environment=environment,
-                    network_spec=network_spec,
+                    network=network,
                     run_mode=mode.value,
                     num_workers=self.__class__.num_parallel_workers,
                     **self.__class__.config

--- a/tensorforce/tests/base_test.py
+++ b/tensorforce/tests/base_test.py
@@ -56,14 +56,14 @@ class BaseTest(object):
         """
         pass
 
-    def base_test_pass(self, name, environment, network_spec, run_mode=RunMode.SINGLE, num_workers=5, **kwargs):
+    def base_test_pass(self, name, environment, network, run_mode=RunMode.SINGLE, num_workers=5, **kwargs):
         """
         Basic test loop, requires an Agent to achieve a certain performance on an environment.
 
         Args:
             name (str): The name of the test.
             environment (Environment): The Environment object to use for the test.
-            network_spec (LayerBasedNetwork): The Network to use for the agent's model.
+            network (LayerBasedNetwork): The Network to use for the agent's model.
             run_mode (int): The run-mode (value of enum RunMode) for this test.
             num_workers (int): For parallel run-modes, how many workers do we use?
             kwargs (any):
@@ -89,7 +89,7 @@ class BaseTest(object):
                 )
 
             if run_mode == RunMode.MULTI_THREADED:
-                agents = clone_worker_agent(agent, num_workers, environment, network_spec, kwargs)
+                agents = clone_worker_agent(agent, num_workers, environment, network, kwargs)
                 environments = [environment]
                 for _ in range(num_workers - 1):
                     environments.append(copy.deepcopy(environment))
@@ -120,7 +120,7 @@ class BaseTest(object):
         sys.stdout.flush()
         self.assertTrue(passed >= 2)
 
-    def base_test_run(self, name, environment, network_spec, run_mode=RunMode.SINGLE, num_workers=5, **kwargs):
+    def base_test_run(self, name, environment, network, run_mode=RunMode.SINGLE, num_workers=5, **kwargs):
         """
         Run test, tests whether algorithm can run and update without compilation errors,
         not whether it passes.
@@ -128,7 +128,7 @@ class BaseTest(object):
         Args:
             name (str): The name of the test.
             environment (Environment): The Environment object to use for the test.
-            network_spec (LayerBasedNetwork): The Network to use for the agent's model.
+            network (LayerBasedNetwork): The Network to use for the agent's model.
             run_mode (int): The run-mode (value of enum RunMode) for this test.
             num_workers (int): For parallel run-modes, how many workers do we use?
             kwargs (any):
@@ -153,7 +153,7 @@ class BaseTest(object):
             )
 
         if run_mode == RunMode.MULTI_THREADED:
-            agents = clone_worker_agent(agent, num_workers, environment, network_spec, kwargs)
+            agents = clone_worker_agent(agent, num_workers, environment, network, kwargs)
             environments = [environment]
             for _ in range(num_workers - 1):
                 environments.append(copy.deepcopy(environment))
@@ -169,7 +169,7 @@ class BaseTest(object):
             ]
             return r.episode < 100 or not all(episodes_passed)
 
-        runner.run(num_episodes=100, deterministic=self.__class__.deterministic, episode_finished=episode_finished)
+        runner.run(num_episodes=100, episode_finished=episode_finished)
         runner.close()
 
         sys.stdout.write('==> {} ran\n'.format(1))

--- a/tensorforce/tests/test_dqn_agent.py
+++ b/tensorforce/tests/test_dqn_agent.py
@@ -47,10 +47,10 @@ class TestDQNAgent(BaseAgentTest, unittest.TestCase):
             type='adam',
             learning_rate=1e-2
         ),
-        # states_preprocessing=[
-        #     dict(type='running_standardize'),
-        #     dict(type='sequence')
-        # ],
+        states_preprocessing=[
+             dict(type='running_standardize'),
+             dict(type='sequence')
+        ],
         target_sync_frequency=10,
         # first_update=64,
         # repeat_update=4,


### PR DESCRIPTION
Fixed sequence and running_standardize preprocessors in memory branch.
Bug fix: model.reset() has to return dict instead of list for self.internals_init.
Fixed counter some stats for Runner/ThreadedRunner.
Fixed some comments (e.g. network vs network_spec) due to new variable naming scheme.