### PR TITLE
internal_lstm: allow passing arbitrary args to LSTMCell()

### DIFF
--- a/tensorforce/core/networks/layer.py
+++ b/tensorforce/core/networks/layer.py
@@ -1080,7 +1080,7 @@ class InternalLstm(Layer):
     Long short-term memory layer for internal state management.
     """
 
-    def __init__(self, size, dropout=None, scope='internal_lstm', summary_labels=()):
+    def __init__(self, size, dropout=None, lstmcell_args={}, scope='internal_lstm', summary_labels=()):
         """
         LSTM layer.
 
@@ -1090,6 +1090,7 @@ class InternalLstm(Layer):
         """
         self.size = size
         self.dropout = dropout
+        self.lstmcell_args = lstmcell_args
         super(InternalLstm, self).__init__(scope=scope, summary_labels=summary_labels)
 
     def tf_apply(self, x, update, state):
@@ -1100,7 +1101,7 @@ class InternalLstm(Layer):
 
         state = tf.contrib.rnn.LSTMStateTuple(c=state[:, 0, :], h=state[:, 1, :])
 
-        self.lstm_cell = tf.contrib.rnn.LSTMCell(num_units=self.size)
+        self.lstm_cell = tf.contrib.rnn.LSTMCell(num_units=self.size, **self.lstmcell_args)
 
         if self.dropout is not None:
             keep_prob = tf.cond(pred=update, true_fn=(lambda: 1.0 - self.dropout), false_fn=(lambda: 1.0))


### PR DESCRIPTION
For consideration. I'm experimenting w/ LSTMCell's `cell_clip=3` param as a way to mitigate _very_ long time-series sequences (vanishing/exploding gradient) from something [I'd read](https://arxiv.org/pdf/1504.01482.pdf). Grain of salt, I'm no expert, so LMK if I'm barking up the wrong tree. Anyway, I'm using this commit https://github.com/lefnire/tensorforce/commit/c33a2648702f6efb29549c98a0adacb47edc291d so I can hyper-search over `cell_clip=[bounded]` & `use_peepholes=[bool]`. I'm thinking maybe it'd just be better to have `lstmcell_args=dict()` which can take any arg LSTMCell would take.