### PR TITLE
Mentioning minimum TF version for  Tensorforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install -e .
 ```
 
 TensorForce is built on [Google's Tensorflow](https://www.tensorflow.org/). The installation command assumes
-that you have `tensorflow` or `tensorflow-gpu` installed.
+that you have `tensorflow` or `tensorflow-gpu` installed. Tensorforce requires Tensorflow version 1.5 or later
 
 Alternatively, you can use the following commands to install the tensorflow dependency.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ pip install -e .
 ```
 
 TensorForce is built on [Google's Tensorflow](https://www.tensorflow.org/). The installation command assumes
-that you have `tensorflow` or `tensorflow-gpu` installed. Tensorforce requires Tensorflow version 1.5 or later
+that you have `tensorflow` or `tensorflow-gpu` installed. Tensorforce requires Tensorflow version 1.5 or later.
 
 Alternatively, you can use the following commands to install the tensorflow dependency.
 


### PR DESCRIPTION
The sampling_body method in replay.py uses tf.while_loop and is given a parameter named as maximum_iterations. This parameter is introduced in Tensorflow version 1.5.  If Tensorflow 1.4 is used for DQN and similar agents, we get unknown args 'maximum_iteration' error