### PR TITLE
Added possibility to specify tensorflow session config for all session types not only distributed

### DIFF
--- a/tensorforce/models/memory_model.py
+++ b/tensorforce/models/memory_model.py
@@ -47,7 +47,8 @@ class MemoryModel(Model):
         update_mode,
         memory,
         optimizer,
-        discount
+        discount,
+        session_config=None
     ):
         """
         Memory model.
@@ -74,6 +75,7 @@ class MemoryModel(Model):
             memory (spec): Memory.
             optimizer (spec): Dict specifying the tf optimizer to use for tuning the model's trainable parameters.
             discount (float): The RL reward discount factor (gamma).
+            session_config: optional tf.ConfigProto with additional desired session configurations
         """
         self.update_mode = update_mode
         self.memory_spec = memory
@@ -103,7 +105,8 @@ class MemoryModel(Model):
             variable_noise=variable_noise,
             states_preprocessing=states_preprocessing,
             actions_exploration=actions_exploration,
-            reward_preprocessing=reward_preprocessing
+            reward_preprocessing=reward_preprocessing,
+            session_config=session_config
         )
 
     def as_local_model(self):

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -81,7 +81,7 @@ class Model(object):
         states_preprocessing,
         actions_exploration,
         reward_preprocessing,
-        session_config=None,
+        session_config=None
     ):
         """
         Model.

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -80,7 +80,8 @@ class Model(object):
         variable_noise,
         states_preprocessing,
         actions_exploration,
-        reward_preprocessing
+        reward_preprocessing,
+        session_config=None,
     ):
         """
         Model.
@@ -103,6 +104,7 @@ class Model(object):
                 "action outputs" (e.g. epsilon-greedy).
             reward_preprocessing (spec): Dict specifying whether and how to preprocess rewards coming
                 from the Environment (e.g. reward normalization).
+            session_config: optional tf.ConfigProto with additional desired session configurations
         """
         # Network crated from network_spec in distribution_model.py
         # Needed for named_tensor access
@@ -128,6 +130,7 @@ class Model(object):
             self.summarizer_spec = summarizer
 
         self.distributed_spec = distributed
+        self.session_config = session_config
 
         # TensorFlow summaries
         if self.summarizer_spec is None:
@@ -522,7 +525,7 @@ class Model(object):
                 hooks=hooks,
                 scaffold=self.scaffold,
                 master='',  # Default value.
-                config=None,  # self.distributed_spec.get('session_config'),
+                config=self.session_config,
                 checkpoint_dir=None
             )
 
@@ -532,7 +535,7 @@ class Model(object):
                 job_name='worker',
                 task_index=self.distributed_spec['task_index'],
                 protocol=self.distributed_spec.get('protocol'),
-                config=self.distributed_spec.get('session_config'),
+                config=self.session_config,
                 start=True
             )
 
@@ -541,7 +544,7 @@ class Model(object):
             session_creator = tf.train.ChiefSessionCreator(
                 scaffold=self.scaffold,
                 master=server.target,
-                config=self.distributed_spec.get('session_config'),
+                config=self.session_config,
                 checkpoint_dir=None,
                 checkpoint_filename_with_path=None
             )
@@ -550,7 +553,7 @@ class Model(object):
             #     session_creator = tf.train.WorkerSessionCreator(
             #         scaffold=self.scaffold,
             #         master=server.target,
-            #         config=self.distributed_spec.get('session_config'),
+            #         config=self.session_config,
             #     )
 
             # TensorFlow monitored session object


### PR DESCRIPTION
Hi!

Thanks for your project.
I started using your project but found that I'm unable to specify tensorflow session config when doing not distributed training.

I found that it was done before in https://github.com/reinforceio/tensorforce/pull/237
But unfortunately now this code does not exist, and it's impossible to set session_config from outside of the library.

Also, I moved session_config from the distributed spec because it's not only distributed functionality (and to not duplicate it in arguments)