### PR TITLE
Independent save and restore of model components

### DIFF
--- a/tensorforce/models/distribution_model.py
+++ b/tensorforce/models/distribution_model.py
@@ -30,6 +30,9 @@ class DistributionModel(MemoryModel):
     Base class for models using distributions parametrized by a neural network.
     """
 
+    COMPONENT_NETWORK = "network"
+    COMPONENT_DISTRIBUTION = "distribution"
+
     def __init__(
         self,
         states,
@@ -272,5 +275,10 @@ class DistributionModel(MemoryModel):
         return model_summaries + network_summaries + distribution_summaries
 
     def get_components(self):
-        model_components = super(DistributionModel, self).get_components()
-        return model_components + [self.network] + list(self.distributions.values())
+        result = dict(super(DistributionModel, self).get_components())
+        result[DistributionModel.COMPONENT_NETWORK] = self.network
+        for action, distribution in self.distributions.items():
+            result["%s_%s" % (DistributionModel.COMPONENT_DISTRIBUTION, action)] = distribution
+        if len(self.distributions) == 1:
+            result[DistributionModel.COMPONENT_DISTRIBUTION] = next(iter(self.distributions.values()))
+        return result

--- a/tensorforce/models/distribution_model.py
+++ b/tensorforce/models/distribution_model.py
@@ -270,3 +270,7 @@ class DistributionModel(MemoryModel):
         ]
 
         return model_summaries + network_summaries + distribution_summaries
+
+    def get_components(self):
+        model_components = super(DistributionModel, self).get_components()
+        return model_components + [self.network] + list(self.distributions.values())

--- a/tensorforce/models/dpg_target_model.py
+++ b/tensorforce/models/dpg_target_model.py
@@ -97,6 +97,10 @@ class DPGTargetModel(DistributionModel):
     Policy gradient model log likelihood model with target network (e.g. DDPG)
     """
 
+    COMPONENT_CRITIC = "critic"
+    COMPONENT_TARGET_NETWORK = "target_network"
+    COMPONENT_TARGET_DISTRIBUTION = "target_distribution"
+
     def __init__(
         self,
         states,
@@ -361,6 +365,11 @@ class DPGTargetModel(DistributionModel):
             + target_distributions_summaries
 
     def get_components(self):
-        model_components = super(DPGTargetModel, self).get_components()
-        target_distribution_components = list(self.target_distributions.values())
-        return model_components + [self.critic, self.target_network] + target_distribution_components
+        result = dict(super(DPGTargetModel, self).get_components())
+        result[DPGTargetModel.COMPONENT_CRITIC] = self.critic
+        result[DPGTargetModel.COMPONENT_TARGET_NETWORK] = self.target_network
+        for action, distribution in self.target_distributions.items():
+            result["%s_%s" % (DPGTargetModel.COMPONENT_TARGET_DISTRIBUTION, action)] = distribution
+        if len(self.target_distributions) == 1:
+            result[DPGTargetModel.COMPONENT_TARGET_DISTRIBUTION] = next(iter(self.target_distributions.values()))
+        return result

--- a/tensorforce/models/dpg_target_model.py
+++ b/tensorforce/models/dpg_target_model.py
@@ -359,3 +359,8 @@ class DPGTargetModel(DistributionModel):
         # Todo: Critic summaries
         return super(DPGTargetModel, self).get_summaries() + target_network_summaries \
             + target_distributions_summaries
+
+    def get_components(self):
+        model_components = super(DPGTargetModel, self).get_components()
+        target_distribution_components = list(self.target_distributions.values())
+        return model_components + [self.critic, self.target_network] + target_distribution_components

--- a/tensorforce/models/memory_model.py
+++ b/tensorforce/models/memory_model.py
@@ -623,3 +623,7 @@ class MemoryModel(Model):
         )
 
         self.monitored_session.run(fetches=fetches, feed_dict=feed_dict)
+
+    def get_components(self):
+        components = super(MemoryModel, self).get_components()
+        return components + [self.memory]

--- a/tensorforce/models/memory_model.py
+++ b/tensorforce/models/memory_model.py
@@ -623,7 +623,3 @@ class MemoryModel(Model):
         )
 
         self.monitored_session.run(fetches=fetches, feed_dict=feed_dict)
-
-    def get_components(self):
-        components = super(MemoryModel, self).get_components()
-        return components + [self.memory]

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -181,6 +181,7 @@ class Model(object):
 
         self.graph = None
         self.global_model = None
+        self.saver = None
         self.scaffold = None
         self.saver_directory = None
         self.session = None
@@ -422,6 +423,9 @@ class Model(object):
             summary_op = tf.summary.merge(inputs=summaries)
         else:
             summary_op = None
+
+        for c in self.get_savable_components():
+            c.register_saver_ops()
 
         # TensorFlow saver object
         self.saver = tf.train.Saver(
@@ -1256,7 +1260,7 @@ class Model(object):
             append_timestep: Appends the current timestep to the checkpoint file if true.
 
         Returns:
-            Checkpoint path were the model was saved.
+            Checkpoint path where the model was saved.
         """
         if self.summarizer_hook is not None:
             self.summarizer_hook._summary_writer.flush()
@@ -1295,3 +1299,22 @@ class Model(object):
         #     raise TensorForceError("Invalid model directory/file.")
 
         self.saver.restore(sess=self.session, save_path=file)
+
+    def get_components(self):
+        """
+        Returns the list of all the components within this model.
+
+        Returns:
+            The list of components.
+        """
+        return list()
+
+    def get_savable_components(self):
+        """
+        Returns the list of all of the components this model consists of that can be individually saved and restored.
+        For instance the network or distribution.
+
+        Returns:
+            List of util.SavableComponent
+        """
+        return filter(lambda x: isinstance(x, util.SavableComponent), self.get_components())

--- a/tensorforce/models/pg_model.py
+++ b/tensorforce/models/pg_model.py
@@ -339,3 +339,10 @@ class PGModel(DistributionModel):
             return super(PGModel, self).get_summaries()
         else:
             return super(PGModel, self).get_summaries() + self.baseline.get_summaries()
+
+    def get_components(self):
+        model_components = super(PGModel, self).get_components()
+        if self.baseline is None:
+            return model_components
+        else:
+            return model_components + [self.baseline]

--- a/tensorforce/models/pg_model.py
+++ b/tensorforce/models/pg_model.py
@@ -31,6 +31,8 @@ class PGModel(DistributionModel):
     subclasses to implement `tf_pg_loss_per_instance`.
     """
 
+    COMPONENT_BASELINE = "baseline"
+
     def __init__(
         self,
         states,
@@ -341,8 +343,9 @@ class PGModel(DistributionModel):
             return super(PGModel, self).get_summaries() + self.baseline.get_summaries()
 
     def get_components(self):
-        model_components = super(PGModel, self).get_components()
         if self.baseline is None:
-            return model_components
+            return super(PGModel, self).get_components()
         else:
-            return model_components + [self.baseline]
+            result = dict(super(PGModel, self).get_components())
+            result[PGModel.COMPONENT_BASELINE] = self.baseline
+            return result

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -30,6 +30,9 @@ class QModel(DistributionModel):
     Q-value model.
     """
 
+    COMPONENT_TARGET_NETWORK = "target_network"
+    COMPONENT_TARGET_DISTRIBUTION = "target_distribution"
+
     def __init__(
         self,
         states,
@@ -285,9 +288,13 @@ class QModel(DistributionModel):
         return super(QModel, self).get_summaries() + target_network_summaries + target_distributions_summaries
 
     def get_components(self):
-        model_components = super(QModel, self).get_components()
-        target_distribution_components = list(self.target_distributions.values())
-        return model_components + [self.target_network] + target_distribution_components
+        result = dict(super(QModel, self).get_components())
+        result[QModel.COMPONENT_TARGET_NETWORK] = self.target_network
+        for action, distribution in self.target_distributions.items():
+            result["%s_%s" % (QModel.COMPONENT_TARGET_DISTRIBUTION, action)] = distribution
+        if len(self.target_distributions) == 1:
+            result[QModel.COMPONENT_TARGET_DISTRIBUTION] = next(iter(self.target_distributions.values()))
+        return result
 
     # # TEMP: Random sampling fix
     # def update(self, states, internals, actions, terminal, reward, return_loss_per_instance=False):

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -284,6 +284,11 @@ class QModel(DistributionModel):
 
         return super(QModel, self).get_summaries() + target_network_summaries + target_distributions_summaries
 
+    def get_components(self):
+        model_components = super(QModel, self).get_components()
+        target_distribution_components = list(self.target_distributions.values())
+        return model_components + [self.target_network] + target_distribution_components
+
     # # TEMP: Random sampling fix
     # def update(self, states, internals, actions, terminal, reward, return_loss_per_instance=False):
     #     fetches = [self.optimization]

--- a/tensorforce/tests/test_model_save_restore.py
+++ b/tensorforce/tests/test_model_save_restore.py
@@ -1,0 +1,181 @@
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+import unittest
+import pytest
+from tensorforce.core.networks import LayeredNetwork
+from tensorforce.tests.minimal_test import MinimalTest
+from tensorforce.agents import PPOAgent
+from tensorforce.execution import Runner
+import tensorflow as tf
+import numpy as np
+from tensorforce.util import SavableComponent
+import os
+
+
+class SavableNetwork(LayeredNetwork, SavableComponent):
+    """
+    Minimal implementation of a Network that can be saved and restored independently of the Model.
+    """
+    def get_savable_variables(self):
+        return super(SavableNetwork, self).get_variables(include_nontrainable=False)
+
+    def _get_base_variable_scope(self):
+        return self.apply.variable_scope_name
+
+
+def create_environment(spec):
+    return MinimalTest(spec)
+
+
+def create_agent(environment, network_spec):
+    return PPOAgent(
+        update_mode=dict(
+            unit='episodes',
+            batch_size=4,
+            frequency=4
+        ),
+        memory=dict(
+            type='latest',
+            include_next_states=False,
+            capacity=100
+        ),
+        step_optimizer=dict(
+            type='adam',
+            learning_rate=1e-3
+        ),
+        subsampling_fraction=0.3,
+        optimization_steps=20,
+        states=environment.states,
+        actions=environment.actions,
+        network=network_spec
+    )
+
+
+class TestModelSaveRestore(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def initdir(self, tmpdir):
+        tmpdir.chdir()
+        self._tmp_dir_path = str(tmpdir)
+        print("Using %s" % (self._tmp_dir_path, ))
+
+    def test_save_restore(self):
+        environment_spec = {"float": ()}
+        environment = create_environment(environment_spec)
+        network_spec = [
+            dict(type='dense', size=32)
+        ]
+        agent = create_agent(environment, network_spec)
+        runner = Runner(agent=agent, environment=environment)
+
+        runner.run(episodes=100)
+        model_values = agent.model.session.run(agent.model.get_variables(
+            include_submodules=True,
+            include_nontrainable=False
+        ))
+        save_path = agent.model.save(directory=self._tmp_dir_path + "/model")
+        print("Saved at: %s" % (save_path,))
+        runner.close()
+
+        agent = create_agent(environment, network_spec)
+        agent.model.restore(directory="", file=save_path)
+        restored_model_values = agent.model.session.run(agent.model.get_variables(
+            include_submodules=True,
+            include_nontrainable=False
+        ))
+        assert len(model_values) == len(restored_model_values)
+        assert all([np.array_equal(v1, v2) for v1, v2 in zip(model_values, restored_model_values)])
+
+        agent.close()
+
+    def test_save_network(self):
+        """
+        Test to validate that calls to save and restore of a SavableComponent successfully save and restore the
+        component's state.
+        """
+
+        environment_spec = {"float": ()}
+        environment = create_environment(environment_spec)
+        network_spec = dict(
+            type=SavableNetwork,
+            layers=[dict(type='dense', size=1)]
+        )
+        agent = create_agent(environment, network_spec)
+        assert isinstance(agent.model.network, SavableComponent)
+
+        runner = Runner(agent=agent, environment=environment)
+        runner.run(episodes=100)
+
+        network_values = agent.model.session.run(agent.model.network.get_variables())
+        distribution = next(iter(agent.model.distributions.values()))
+        distribution_values = agent.model.session.run(distribution.get_variables())
+        save_path = self._tmp_dir_path + "/network"
+        agent.model.network.save(sess=agent.model.session, save_path=save_path)
+        runner.close()
+
+        assert os.path.isfile(save_path + ".data-00000-of-00001")
+        assert os.path.isfile(save_path + ".index")
+
+        agent = create_agent(environment, network_spec)
+        agent.model.network.restore(
+            sess=agent.model.session,
+            save_path=save_path
+        )
+
+        # Ensure only the network variables are loaded
+        restored_network_values = agent.model.session.run(agent.model.network.get_variables(include_nontrainable=True))
+        distribution = next(iter(agent.model.distributions.values()))
+        restored_distribution_values = agent.model.session.run(distribution.get_variables())
+
+        assert len(restored_network_values) == len(network_values)
+        assert all([np.array_equal(v1, v2) for v1, v2 in zip(network_values, restored_network_values)])
+        assert len(restored_distribution_values) == len(distribution_values)
+        assert not all([np.array_equal(v1, v2) for v1, v2 in zip(distribution_values, restored_distribution_values)])
+
+        agent.close()
+        environment.close()
+
+    def test_pretrain_network(self):
+        """
+        Simulates training outside of Tensorforce and then loading the parameters in the agent's network.
+        """
+
+        environment_spec = {"float": ()}
+        environment = create_environment(environment_spec)
+        size = environment.states["shape"]
+        output_size = 1
+        save_path = self._tmp_dir_path + "/network"
+
+        g = tf.Graph()
+        with g.as_default():
+            x = tf.placeholder(dtype=environment.states["type"], shape=[None, size])
+            layer = tf.layers.Dense(units=output_size)
+            y = layer(x)
+            y_ = tf.placeholder(dtype=environment.states["type"], shape=[None, output_size])
+            loss = tf.losses.mean_squared_error(y_, y)
+            optimizer = tf.train.AdamOptimizer(learning_rate=0.1)
+            train_step = optimizer.minimize(loss)
+            batch_size = 64
+            with tf.Session(graph=g) as sess:
+                sess.run(tf.global_variables_initializer())
+                for epoch in range(100):
+                    batch = np.random.random([batch_size, size])
+                    correct = np.ones(shape=[batch.shape[0], output_size])
+                    loss_value, _ = sess.run([loss, train_step], {x: batch, y_: correct})
+                    if epoch % 10 == 0:
+                        print("epoch %d: %f" % (epoch, loss_value))
+                var_map = {
+                    "dense0/apply/linear/apply/W:0": layer.kernel,
+                    "dense0/apply/linear/apply/b:0": layer.bias
+                }
+                saver = tf.train.Saver(var_list=var_map)
+                saver.save(sess=sess, write_meta_graph=False, save_path=save_path)
+
+        network_spec = dict(
+            type=SavableNetwork,
+            layers=[dict(type='dense', size=output_size)],
+        )
+        agent = create_agent(environment, network_spec)
+        agent.model.network.restore(sess=agent.model.session, save_path=save_path)
+        agent.close()


### PR DESCRIPTION
This change introduces the mixin `SavableComponent` that model
components that are to be saved or restored independently from the
model should extend from.

The Model calls `register_saver_ops` of each savable component when
computation graph is constructed and save operations can be added to
it.

Note that with this change the save and restore of the savable
components need to be called explicitly. Model's save, restore and
checkpoint functionality does not delegate to the savable components'
save and restore methods.

A simple recipe to train/preload embeddings can be found in
TestModelSaveRestore.test_pretrain_network