### PR TITLE
Cleanup and decomposition of model.py:setup() in preparation of "distributed/execution"-project(s)

### DIFF
--- a/examples/configs/dqn_ue4.json
+++ b/examples/configs/dqn_ue4.json
@@ -43,6 +43,7 @@
         "directory": null,
         "seconds": 600
     },
+
     "summarizer": {
         "directory": null,
         "labels": [],

--- a/examples/configs/dqn_visual.json
+++ b/examples/configs/dqn_visual.json
@@ -1,10 +1,18 @@
 {
     "type": "dqn_agent",
-    "batch_size": 64,
+
+    "update_mode": {
+        "unit": "timesteps",
+        "batch_size": 64,
+        "frequency": 4
+    },
+
     "memory": {
         "type": "replay",
-        "capacity": 10000
+        "capacity": 10000,
+        "include_next_states": true
     },
+
     "optimizer": {
       "type": "adam",
       "learning_rate": 1e-3
@@ -38,6 +46,7 @@
         "directory": null,
         "seconds": 600
     },
+
     "summarizer": {
         "directory": null,
         "labels": [],

--- a/tensorforce/agents/constant_agent.py
+++ b/tensorforce/agents/constant_agent.py
@@ -19,6 +19,7 @@ from __future__ import division
 
 from tensorforce.agents import Agent
 from tensorforce.models.constant_model import ConstantModel
+from tensorforce.contrib.sanity_check_specs import sanity_check_execution_spec
 
 
 class ConstantAgent(Agent):
@@ -37,7 +38,7 @@ class ConstantAgent(Agent):
         device=None,
         saver=None,
         summarizer=None,
-        distributed=None
+        execution=None
     ):
         """
         Initializes the constant agent.
@@ -59,22 +60,14 @@ class ConstantAgent(Agent):
                 - seconds or steps: summarize frequency (default: 120 seconds).
                 - labels: list of summary labels to record (default: []).
                 - meta_param_recorder_class: ???.
-            distributed (spec): Distributed specification, with the following attributes (default:
-                none):
-                - cluster_spec: TensorFlow ClusterSpec object (required).
-                - task_index: integer (required).
-                - parameter_server: specifies whether this instance is a parameter server (default:
-                    false).
-                - protocol: communication protocol (default: none, i.e. 'grpc').
-                - config: TensorFlow ConfigProto object (default: none).
-                - replica_model: internal.
+            execution (spec): Execution specification (see sanity_check_execution_spec for details).
         """
 
         self.scope = scope
         self.device = device
         self.saver = saver
         self.summarizer = summarizer
-        self.distributed = distributed
+        self.execution = sanity_check_execution_spec(execution)
         self.batching_capacity = batching_capacity
         self.action_values = action_values
 
@@ -93,7 +86,7 @@ class ConstantAgent(Agent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             action_values=self.action_values
         )

--- a/tensorforce/agents/ddpg_agent.py
+++ b/tensorforce/agents/ddpg_agent.py
@@ -148,7 +148,7 @@ class DDPGAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/agents/dqfd_agent.py
+++ b/tensorforce/agents/dqfd_agent.py
@@ -161,7 +161,7 @@ class DQFDAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/agents/dqn_agent.py
+++ b/tensorforce/agents/dqn_agent.py
@@ -139,7 +139,7 @@ class DQNAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/agents/dqn_nstep_agent.py
+++ b/tensorforce/agents/dqn_nstep_agent.py
@@ -136,7 +136,7 @@ class DQNNstepAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            distributed=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/agents/learning_agent.py
+++ b/tensorforce/agents/learning_agent.py
@@ -19,9 +19,9 @@ from __future__ import division
 
 import inspect
 
-from tensorforce import TensorForceError
 from tensorforce.agents.agent import Agent
 from tensorforce.meta_parameter_recorder import MetaParameterRecorder
+from tensorforce.contrib.sanity_check_specs import sanity_check_execution_spec
 
 
 class LearningAgent(Agent):
@@ -82,15 +82,7 @@ class LearningAgent(Agent):
                 - seconds or steps: summarize frequency (default: 120 seconds).
                 - labels: list of summary labels to record (default: []).
                 - meta_param_recorder_class: ???.
-            execution (spec): Distributed specification, with the following attributes (default:
-                none):
-                - cluster_spec: TensorFlow ClusterSpec object (required).
-                - task_index: integer (required).
-                - parameter_server: specifies whether this instance is a parameter server (default:
-                    false).
-                - protocol: communication protocol (default: none, i.e. 'grpc').
-                - config: TensorFlow ConfigProto object (default: none).
-                - replica_model: internal.
+            execution (spec): Execution specification (see sanity_check_execution_spec for details).
             variable_noise (float): Standard deviation of variable noise (default: none).
             states_preprocessing (spec, or dict of specs): States preprocessing specification, see
                 core.preprocessors module for more information (default: none)
@@ -108,7 +100,7 @@ class LearningAgent(Agent):
         self.device = device
         self.saver = saver
         self.summarizer = summarizer
-        self.distributed = execution
+        self.execution = sanity_check_execution_spec(execution)
         self.variable_noise = variable_noise
         self.states_preprocessing = states_preprocessing
         self.actions_exploration = actions_exploration

--- a/tensorforce/agents/naf_agent.py
+++ b/tensorforce/agents/naf_agent.py
@@ -139,7 +139,7 @@ class NAFAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/agents/ppo_agent.py
+++ b/tensorforce/agents/ppo_agent.py
@@ -159,7 +159,7 @@ class PPOAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/agents/random_agent.py
+++ b/tensorforce/agents/random_agent.py
@@ -19,6 +19,7 @@ from __future__ import division
 
 from tensorforce.agents import Agent
 from tensorforce.models.random_model import RandomModel
+from tensorforce.contrib.sanity_check_specs import sanity_check_execution_spec
 
 
 class RandomAgent(Agent):
@@ -36,7 +37,7 @@ class RandomAgent(Agent):
         device=None,
         saver=None,
         summarizer=None,
-        distributed=None,
+        execution=None,
     ):
         """
         Initializes the random agent.
@@ -56,22 +57,14 @@ class RandomAgent(Agent):
                 - seconds or steps: summarize frequency (default: 120 seconds).
                 - labels: list of summary labels to record (default: []).
                 - meta_param_recorder_class: ???.
-            distributed (spec): Distributed specification, with the following attributes (default:
-                none):
-                - cluster_spec: TensorFlow ClusterSpec object (required).
-                - task_index: integer (required).
-                - parameter_server: specifies whether this instance is a parameter server (default:
-                    false).
-                - protocol: communication protocol (default: none, i.e. 'grpc').
-                - config: TensorFlow ConfigProto object (default: none).
-                - replica_model: internal.
+            execution (spec): Execution specification (see sanity_check_execution_spec for details).
         """
 
         self.scope = scope
         self.device = device
         self.saver = saver
         self.summarizer = summarizer
-        self.distributed = distributed
+        self.execution = sanity_check_execution_spec(execution)
 
         super(RandomAgent, self).__init__(
             states=states,
@@ -88,6 +81,6 @@ class RandomAgent(Agent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity
         )

--- a/tensorforce/agents/trpo_agent.py
+++ b/tensorforce/agents/trpo_agent.py
@@ -166,7 +166,7 @@ class TRPOAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            execution=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             discount=self.discount,
             variable_noise=self.variable_noise,

--- a/tensorforce/agents/vpg_agent.py
+++ b/tensorforce/agents/vpg_agent.py
@@ -141,7 +141,7 @@ class VPGAgent(LearningAgent):
             device=self.device,
             saver=self.saver,
             summarizer=self.summarizer,
-            distributed=self.distributed,
+            execution=self.execution,
             batching_capacity=self.batching_capacity,
             variable_noise=self.variable_noise,
             states_preprocessing=self.states_preprocessing,

--- a/tensorforce/contrib/sanity_check_specs.py
+++ b/tensorforce/contrib/sanity_check_specs.py
@@ -133,7 +133,9 @@ def sanity_check_execution_spec(execution_spec):
             "ps": ["localhost:22222"],
             "worker": ["localhost:22223"]
         })
-        execution_spec["distributed_spec"] = def_.update(execution_spec.get("distributed_spec", {}))
+        def_.update(execution_spec.get("distributed_spec", {}))
+        execution_spec["distributed_spec"] = def_
+        execution_spec["session_config"] = execution_spec.get("session_config")
         return execution_spec
     elif type_ == "multi-threaded":
         return execution_spec

--- a/tensorforce/contrib/sanity_check_specs.py
+++ b/tensorforce/contrib/sanity_check_specs.py
@@ -1,0 +1,143 @@
+# Copyright 2017 reinforce.io. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+from tensorforce import TensorForceError
+import copy
+
+
+def sanity_check_states(states_spec):
+    """
+    Sanity checks a states dict, used to define the state space for an MDP.
+    Throws an error or warns if mismatches are found.
+
+    Args:
+        states_spec (Union[None,dict]): The spec-dict to check (or None).
+
+    Returns: Tuple of 1) the state space desc and 2) whether there is only one component in the state space.
+    """
+    # Leave incoming states dict intact.
+    states = copy.deepcopy(states_spec)
+
+    # Unique state shortform.
+    is_unique = ('shape' in states)
+    if is_unique:
+        states = dict(state=states)
+
+    # Normalize states.
+    for name, state in states.items():
+        # Convert int to unary tuple.
+        if isinstance(state['shape'], int):
+            state['shape'] = (state['shape'],)
+
+        # Set default type to float.
+        if 'type' not in state:
+            state['type'] = 'float'
+
+    return states, is_unique
+
+
+def sanity_check_actions(actions_spec):
+    """
+    Sanity checks an actions dict, used to define the action space for an MDP.
+    Throws an error or warns if mismatches are found.
+
+    Args:
+        actions_spec (Union[None,dict]): The spec-dict to check (or None).
+
+    Returns: Tuple of 1) the action space desc and 2) whether there is only one component in the action space.
+    """
+    # Leave incoming spec-dict intact.
+    actions = copy.deepcopy(actions_spec)
+
+    # Unique action shortform.
+    is_unique = ('type' in actions)
+    if is_unique:
+        actions = dict(action=actions)
+
+    # Normalize actions.
+    for name, action in actions.items():
+        # Set default type to int
+        if 'type' not in action:
+            action['type'] = 'int'
+
+        # Check required values
+        if action['type'] == 'int':
+            if 'num_actions' not in action:
+                raise TensorForceError("Action requires value 'num_actions' set!")
+        elif action['type'] == 'float':
+            if ('min_value' in action) != ('max_value' in action):
+                raise TensorForceError("Action requires both values 'min_value' and 'max_value' set!")
+
+        # Set default shape to empty tuple (single-int, discrete action space)
+        if 'shape' not in action:
+            action['shape'] = ()
+
+        # Convert int to unary tuple
+        if isinstance(action['shape'], int):
+            action['shape'] = (action['shape'],)
+
+    return actions, is_unique
+
+
+def sanity_check_execution_spec(execution_spec):
+    """
+    Sanity checks a execution_spec dict, used to define execution logic (distributed vs single, shared memories, etc..)
+    and distributed learning behavior of agents/models.
+    Throws an error or warns if mismatches are found.
+
+    Args:
+        execution_spec (Union[None,dict]): The spec-dict to check (or None). Dict needs to have the following keys:
+            - type: "single", "distributed"
+            - distributed_spec: The distributed_spec dict with the following fields:
+                - cluster_spec: TensorFlow ClusterSpec object (required).
+                - job: The tf-job name.
+                - task_index: integer (required).
+                - protocol: communication protocol (default: none, i.e. 'grpc').
+            - session_config: dict with options for a TensorFlow ConfigProto object (default: None).
+
+    Returns: A cleaned-up (in-place) version of the given execution-spec.
+    """
+
+    # default spec: single mode
+    def_ = dict(type="single",
+                distributed_spec=None,
+                session_config=None)
+
+    if execution_spec is None:
+        return def_
+
+    assert isinstance(execution_spec, dict), "ERROR: execution-spec needs to be of type dict (but is of type {})!".\
+        format(type(execution_spec).__name__)
+
+    type_ = execution_spec.get("type")
+
+    # TODO: Figure out what exactly we need for options and what types we should support.
+    if type_ == "distributed":
+        def_ = dict(job="ps", task=0, cluster_spec={
+            "ps": ["localhost:22222"],
+            "worker": ["localhost:22223"]
+        })
+        execution_spec["distributed_spec"] = def_.update(execution_spec.get("distributed_spec", {}))
+        return execution_spec
+    elif type_ == "multi-threaded":
+        return execution_spec
+    elif type_ == "single":
+        return execution_spec
+
+    raise TensorForceError("Unsupported execution type specified ({})!".format(type_))

--- a/tensorforce/models/memory_model.py
+++ b/tensorforce/models/memory_model.py
@@ -473,6 +473,18 @@ class MemoryModel(Model):
         return self.optimizer.minimize(**arguments)
 
     def tf_observe_timestep(self, states, internals, actions, terminal, reward):
+        """
+
+        Args:
+            states ():
+            internals ():
+            actions ():
+            terminal ():
+            reward ():
+
+        Returns:
+
+        """
         # Store timestep in memory
         stored = self.memory.store(
             states=states,
@@ -536,13 +548,11 @@ class MemoryModel(Model):
                 tensors=batch
             )
 
-            optimization = tf.cond(
+            return tf.cond(
                 pred=optimize,
                 true_fn=(lambda: self.fn_optimization(**batch)),
                 false_fn=tf.no_op
             )
-
-        return optimization
 
     def tf_import_experience(self, states, internals, actions, terminal, reward):
         """

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -1239,7 +1239,7 @@ class Model(object):
         #     feed_dict = {self.terminal_input: (terminal,), self.reward_input: (reward,)}
 
         self.is_observe = True
-        episode = self.monitored_session.raw_session().run(fetches=fetches, feed_dict=feed_dict)
+        episode = self.monitored_session.run(fetches=fetches, feed_dict=feed_dict)
         self.is_observe = False
 
         return episode

--- a/tensorforce/tests/test_vpg_multithreaded.py
+++ b/tensorforce/tests/test_vpg_multithreaded.py
@@ -71,7 +71,7 @@ class TestVPGMultithreaded(unittest.TestCase):
 
         runner = ThreadedRunner(agent=agents, environment=environments)
 
-        runner.run(episodes=100)
+        runner.run(num_episodes=100)
         runner.close()
 
         sys.stdout.write(' ran\n')

--- a/tensorforce/util.py
+++ b/tensorforce/util.py
@@ -110,6 +110,22 @@ def map_tensors(fn, tensors):
         return fn(tensors)
 
 
+def get_tensor_dependencies(tensor):
+    """
+    Utility method to get all dependencies (including placeholders) of a tensor (backwards through the graph).
+
+    Args:
+        tensor (tf.Tensor): The input tensor.
+
+    Returns: Set of all dependencies (including needed placeholders) for the input tensor.
+    """
+    dependencies = set()
+    dependencies.update(tensor.op.inputs)
+    for sub_op in tensor.op.inputs:
+        dependencies.update(get_tensor_dependencies(sub_op))
+    return dependencies
+
+
 def get_object(obj, predefined_objects=None, default_object=None, kwargs=None):
     """
     Utility method to map some kind of object specification to its content,
@@ -178,6 +194,7 @@ def prepare_kwargs(raw, string_parameter='name'):
         kwargs[string_parameter] = raw
 
     return kwargs
+
 
 class UpdateSummarySaverHook(tf.train.SummarySaverHook):
 


### PR DESCRIPTION
Minor refactoring for the model.py:setup() method.
Cleaned it up a little and broke it down into smaller, more comprehensive chunks:
- init graph
- start server
- build graph
- saver
- summaries
- scaffold
- session-hooks
- session

Added sanity checkers and pre-processors for some spec-dicts (state, action, execution) to contrib/sanity_check_specs.py. This is to keep spec-logic and sanity checking in one place. Other specs can be added.

This is in preparation of the upcoming execution/distributed RL changes.

Test are all pass.

Next, I'll go through running a distributed DQN agent (bundled mode) and see what needs to be done with the memories for making distributed work. But maybe it's already ok.

Then I'll add more and more distributed/execution options.
