### PR TITLE
Further cleanup of model.py:setup().

### DIFF
--- a/tensorforce/contrib/sanity_check_specs.py
+++ b/tensorforce/contrib/sanity_check_specs.py
@@ -129,7 +129,7 @@ def sanity_check_execution_spec(execution_spec):
 
     # TODO: Figure out what exactly we need for options and what types we should support.
     if type_ == "distributed":
-        def_ = dict(job="ps", task=0, cluster_spec={
+        def_ = dict(job="ps", task_index=0, cluster_spec={
             "ps": ["localhost:22222"],
             "worker": ["localhost:22223"]
         })

--- a/tensorforce/core/memories/memory.py
+++ b/tensorforce/core/memories/memory.py
@@ -25,18 +25,16 @@ import tensorforce.core.memories
 
 class Memory(object):
     """
-    Base class for memories.
+    Base class for memories. A Memory stores records of the type: "state/action/reward/(next-state)?/is-terminal".
     """
 
     def __init__(self, states, internals, actions, include_next_states, scope='memory', summary_labels=None):
         """
-        Memory.
-
         Args:
-            states: States specifiction.
-            internals: Internal states specification.
-            actions: Actions specification.
-            include_next_states: Include subsequent state if true.
+            states (dict): States specification.
+            internals (dict): Internal states specification.
+            actions (dict): Actions specification.
+            include_next_states (bool): Include subsequent state if true.
         """
         self.states_spec = states
         self.internals_spec = internals
@@ -87,7 +85,7 @@ class Memory(object):
 
     def tf_initialize(self):
         """
-        Initializes memory.
+        Initializes the memory. Called by a memory-model in its own tf_initialize method.
         """
         raise NotImplementedError
 

--- a/tensorforce/core/memories/prioritized_replay.py
+++ b/tensorforce/core/memories/prioritized_replay.py
@@ -87,7 +87,7 @@ class PrioritizedReplay(Memory):
         )
 
     def setup_template_funcs(self, custom_getter=None):
-        super(PrioritizedReplay, self).setup_template_funcs(custom_getter)
+        custom_getter = super(PrioritizedReplay, self).setup_template_funcs(custom_getter)
 
         self.retrieve_indices = tf.make_template(
             name_=(self.scope + '/retrieve_indices'),

--- a/tensorforce/core/memories/queue.py
+++ b/tensorforce/core/memories/queue.py
@@ -49,6 +49,16 @@ class Queue(Memory):
         )
         self.capacity = capacity
 
+        # Pieces of the records are stored in different tensors:
+        self.states_memory = dict()  # keys=state space components
+        self.internals_memory = dict()  # keys=internal state components
+        self.actions_memory = dict()  # keys=action space components
+        self.terminal_memory = None  # 1D tensor
+        self.reward_memory = None  # 1D tensor
+        self.memory_index = None  # 0D (int) tensor (points to the next record to be overwritten)
+        self.episode_indices = None  # 1D tensor of indexes where episodes start.
+        self.episode_count = None  # 0D (int) tensor: How many episodes do we have stored?
+
         def custom_getter(getter, name, registered=False, **kwargs):
             variable = getter(name=name, registered=True, **kwargs)
             if not registered:
@@ -64,7 +74,6 @@ class Queue(Memory):
 
     def tf_initialize(self):
         # States
-        self.states_memory = dict()
         for name, state in self.states_spec.items():
             self.states_memory[name] = tf.get_variable(
                 name=('state-' + name),
@@ -74,7 +83,6 @@ class Queue(Memory):
             )
 
         # Internals
-        self.internals_memory = dict()
         for name, internal in self.internals_spec.items():
             self.internals_memory[name] = tf.get_variable(
                 name=('internal-' + name),
@@ -84,7 +92,6 @@ class Queue(Memory):
             )
 
         # Actions
-        self.actions_memory = dict()
         for name, action in self.actions_spec.items():
             self.actions_memory[name] = tf.get_variable(
                 name=('action-' + name),

--- a/tensorforce/core/memories/queue.py
+++ b/tensorforce/core/memories/queue.py
@@ -33,21 +33,10 @@ class Queue(Memory):
         Queue memory.
 
         Args:
-            states: States specifiction.
-            internals: Internal states specification.
-            actions: Actions specification.
-            include_next_states: Include subsequent state if true.
             capacity: Memory capacity.
         """
-        super(Queue, self).__init__(
-            states=states,
-            internals=internals,
-            actions=actions,
-            include_next_states=include_next_states,
-            scope=scope,
-            summary_labels=summary_labels
-        )
         self.capacity = capacity
+        self.scope = scope
 
         # Pieces of the records are stored in different tensors:
         self.states_memory = dict()  # keys=state space components
@@ -59,15 +48,22 @@ class Queue(Memory):
         self.episode_indices = None  # 1D tensor of indexes where episodes start.
         self.episode_count = None  # 0D (int) tensor: How many episodes do we have stored?
 
-        def custom_getter(getter, name, registered=False, **kwargs):
-            variable = getter(name=name, registered=True, **kwargs)
-            if not registered:
-                assert not kwargs.get('trainable', False)
-                self.variables[name] = variable
-            return variable
+        self.retrieve_indices = None
+
+        super(Queue, self).__init__(
+            states=states,
+            internals=internals,
+            actions=actions,
+            include_next_states=include_next_states,
+            scope=scope,
+            summary_labels=summary_labels
+        )
+
+    def setup_template_funcs(self, custom_getter=None):
+        custom_getter = super(Queue, self).setup_template_funcs(custom_getter=custom_getter)
 
         self.retrieve_indices = tf.make_template(
-            name_=(scope + '/retrieve_indices'),
+            name_=(self.scope + '/retrieve_indices'),
             func_=self.tf_retrieve_indices,
             custom_getter_=custom_getter
         )

--- a/tensorforce/core/memories/replay.py
+++ b/tensorforce/core/memories/replay.py
@@ -32,11 +32,11 @@ class Replay(Queue):
         Replay memory.
 
         Args:
-            states: States specification.
-            internals: Internal states specification.
-            actions: Actions specification.
-            include_next_states: Include subsequent state if true.
-            capacity: Memory capacity.
+            states (dict): States specification.
+            internals (dict): Internal states specification.
+            actions (dict): Actions specification.
+            include_next_states (bool): Include subsequent state if true.
+            capacity (int): Memory capacity (number of state/internals/action/(next-state)? records).
         """
         super(Replay, self).__init__(
             states=states,

--- a/tensorforce/core/networks/layer.py
+++ b/tensorforce/core/networks/layer.py
@@ -219,7 +219,7 @@ class Nonlinearity(Layer):
         Non-linearity activation layer.
 
         Args:
-            name: Non-linearity name, one of 'elu', 'relu', 'selu', 'sigmoid', 'swish', 'softmax', 
+            name: Non-linearity name, one of 'elu', 'relu', 'selu', 'sigmoid', 'swish',
                 'leaky_relu' (or 'lrelu'), 'crelu', 'softmax', 'softplus', 'softsign', 'tanh' or 'none'.
             alpha: (float|int) Alpha value for leaky Relu
             beta: (float|int|'learn') Beta value or 'learn' to train value (default 1.0)

--- a/tensorforce/core/optimizers/__init__.py
+++ b/tensorforce/core/optimizers/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+from functools import partial
 from tensorforce.core.optimizers.optimizer import Optimizer
 from tensorforce.core.optimizers.meta_optimizer import MetaOptimizer
 from tensorforce.core.optimizers.global_optimizer import GlobalOptimizer
@@ -29,13 +30,13 @@ from tensorforce.core.optimizers.synchronization import Synchronization
 # This can register any class inheriting from tf.train.Optimizer
 optimizers = dict(
     global_optimizer=GlobalOptimizer,
-    adadelta=TFOptimizer.get_wrapper(optimizer='adadelta'),
-    adagrad=TFOptimizer.get_wrapper(optimizer='adagrad'),
-    adam=TFOptimizer.get_wrapper(optimizer='adam'),
-    nadam=TFOptimizer.get_wrapper(optimizer='nadam'),
-    gradient_descent=TFOptimizer.get_wrapper(optimizer='gradient_descent'),
-    momentum=TFOptimizer.get_wrapper(optimizer='momentum'),
-    rmsprop=TFOptimizer.get_wrapper(optimizer='rmsprop'),
+    adadelta=partial(TFOptimizer, 'adadelta'),
+    adagrad=partial(TFOptimizer, 'adagrad'),
+    adam=partial(TFOptimizer, 'adam'),
+    nadam=partial(TFOptimizer, 'nadam'),
+    gradient_descent=partial(TFOptimizer, 'gradient_descent'),
+    momentum=partial(TFOptimizer, 'momentum'),
+    rmsprop=partial(TFOptimizer, 'rmsprop'),
     evolutionary=Evolutionary,
     natural_gradient=NaturalGradient,
     clipped_step=ClippedStep,

--- a/tensorforce/core/optimizers/global_optimizer.py
+++ b/tensorforce/core/optimizers/global_optimizer.py
@@ -41,19 +41,17 @@ class GlobalOptimizer(MetaOptimizer):
         """
         super(GlobalOptimizer, self).__init__(optimizer=optimizer, scope=scope, summary_labels=summary_labels)
 
-    def tf_step(self, time, variables, global_variables, **kwargs):
+    def tf_step(self, time, variables, **kwargs):
         """
-        Creates the TensorFlow operations for performing an optimization step.
-
-        Args:
-            time: Time tensor.
-            variables: List of variables to optimize.
+        Keyword Args:
             global_variables: List of global variables to apply the proposed optimization step to.
-            **kwargs: ??? coming soon
 
         Returns:
             List of delta tensors corresponding to the updates for each optimized variable.
         """
+
+        global_variables = kwargs["global_variables"]
+
         assert all(
             util.shape(global_variable) == util.shape(local_variable)
             for global_variable, local_variable in zip(global_variables, variables)

--- a/tensorforce/core/optimizers/optimizer.py
+++ b/tensorforce/core/optimizers/optimizer.py
@@ -55,7 +55,8 @@ class Optimizer(object):
 
     def tf_step(self, time, variables, **kwargs):
         """
-        Creates the TensorFlow operations for performing an optimization step.
+        Creates the TensorFlow operations for performing an optimization step on the given variables, including
+        actually changing the values of the variables.
 
         Args:
             time: Time tensor.
@@ -70,14 +71,14 @@ class Optimizer(object):
 
     def apply_step(self, variables, deltas):
         """
-        Applies step deltas to variable values.
+        Applies the given (and already calculated) step deltas to the variable values.
 
         Args:
             variables: List of variables.
             deltas: List of deltas of same length.
 
         Returns:
-            The step-applied operation.
+            The step-applied operation. A tf.group of tf.assign_add ops.
         """
         if len(variables) != len(deltas):
             raise TensorForceError("Invalid variables and deltas lists.")

--- a/tensorforce/environments/__init__.py
+++ b/tensorforce/environments/__init__.py
@@ -15,11 +15,6 @@
 
 
 from tensorforce.environments.environment import Environment
-from tensorforce.tests.minimal_test import MinimalTest
 
-
-environments = dict(
-    minimal_test=MinimalTest,
-)
-
-__all__ = ['Environment', 'MinimalTest']
+# had to take out MinimalTest due to circular dependency
+__all__ = ['Environment']

--- a/tensorforce/models/dpg_target_model.py
+++ b/tensorforce/models/dpg_target_model.py
@@ -169,8 +169,8 @@ class DPGTargetModel(DistributionModel):
         assert self.memory_spec["include_next_states"]
         assert self.requires_deterministic == True
 
-    def initialize(self, custom_getter):
-        super(DPGTargetModel, self).initialize(custom_getter)
+    def setup_components_and_tf_funcs(self, custom_getter=None):
+        custom_getter = super(DPGTargetModel, self).setup_components_and_tf_funcs(custom_getter)
 
         # Target network
         self.target_network = Network.from_spec(
@@ -216,6 +216,7 @@ class DPGTargetModel(DistributionModel):
             func_=self.tf_predict_target_q,
             custom_getter_=custom_getter
         )
+        return custom_getter
 
     def tf_target_actions_and_internals(self, states, internals, deterministic=True):
         embedding, internals = self.target_network.apply(

--- a/tensorforce/models/memory_model.py
+++ b/tensorforce/models/memory_model.py
@@ -27,7 +27,12 @@ from tensorforce.models import Model
 
 class MemoryModel(Model):
     """
-    A memory model is a generical model to accumulate and sample data.
+    A memory model is a generic model to accumulate and sample data.
+
+    Child classes need to implement the following methods:
+    - `tf_loss_per_instance(states, internals, actions, terminal, reward)` returning the loss
+        per instance for a batch.
+    - `tf_regularization_losses(states, internals)` returning a dict of regularization losses.
     """
 
     def __init__(
@@ -85,11 +90,14 @@ class MemoryModel(Model):
 
         self.memory = None
         self.optimizer = None
+
         self.fn_discounted_cumulative_reward = None
+        self.fn_reference = None
         self.fn_loss_per_instance = None
         self.fn_regularization_losses = None
         self.fn_loss = None
         self.fn_optimization = None
+        self.fn_import_experience = None
 
         super(MemoryModel, self).__init__(
             states=states,
@@ -107,14 +115,21 @@ class MemoryModel(Model):
         )
 
     def as_local_model(self):
+        """
+        Makes sure our optimizer is wrapped into the global_optimizer meta. This is only relevant for distributed RL.
+        """
         super(MemoryModel, self).as_local_model()
         self.optimizer_spec = dict(
             type='global_optimizer',
             optimizer=self.optimizer_spec
         )
 
-    def initialize(self, custom_getter):
-        super(MemoryModel, self).initialize(custom_getter)
+    def setup_components_and_tf_funcs(self, custom_getter=None):
+        """
+        Constructs the memory and the optimizer objects.
+        Generates and stores all template functions.
+        """
+        custom_getter = super(MemoryModel, self).setup_components_and_tf_funcs(custom_getter)
 
         # Memory
         self.memory = Memory.from_spec(
@@ -170,131 +185,136 @@ class MemoryModel(Model):
             custom_getter_=custom_getter
         )
 
+        return custom_getter
+
     def tf_initialize(self):
+        """
+        Also initializes our Memory object (self.memory).
+        """
         super(MemoryModel, self).tf_initialize()
         self.memory.initialize()
 
-    def tf_discounted_cumulative_reward(self, terminal, reward, discount, final_reward=0.0):
+    #def tf_discounted_cumulative_reward(self, terminal, reward, discount, final_reward=0.0):
+    #    """
+    #    Creates the TensorFlow operations for calculating the discounted cumulative rewards
+    #    for a given sequence of rewards.
+
+    #    Args:
+    #        terminal: Terminal boolean tensor.
+    #        reward: Reward tensor.
+    #        discount: Discount factor.
+    #        final_reward: Last reward value in the sequence.
+
+    #    Returns:
+    #        Discounted cumulative reward tensor.
+    #    """
+
+    #    # TODO: n-step cumulative reward (particularly for envs without terminal)
+
+    #    def cumulate(cumulative, reward_and_terminal):
+    #        rew, term = reward_and_terminal
+    #        return tf.where(condition=term, x=rew, y=(rew + cumulative * discount))
+
+    #    # Reverse since reward cumulation is calculated right-to-left, but tf.scan only works left-to-right
+    #    reward = tf.reverse(tensor=reward, axis=(0,))
+    #    terminal = tf.reverse(tensor=terminal, axis=(0,))
+
+    #    reward = tf.scan(fn=cumulate, elems=(reward, terminal), initializer=tf.stop_gradient(input=final_reward))
+
+    #    return tf.reverse(tensor=reward, axis=(0,))
+
+    # TODO: could be a utility helper function if we remove self.discount and only allow external discount-value input
+    def tf_discounted_cumulative_reward(self, terminal, reward, discount=None, final_reward=0.0, horizon=0):
         """
-        Creates the TensorFlow operations for calculating the discounted cumulative rewards
-        for a given sequence of rewards.
+        Creates and returns the TensorFlow operations for calculating the sequence of discounted cumulative rewards
+        for a given sequence of single rewards.
+
+        Example:
+        single rewards = 2.0 1.0 0.0 0.5 1.0 -1.0
+        terminal = False, False, False, False True False
+        gamma = 0.95
+        final_reward = 100.0 (only matters for last episode (r=-1.0) as this episode has no terminal signal)
+        horizon=3
+        output = 2.95 1.45 1.38 1.45 1.0 94.0
 
         Args:
-            terminal: Terminal boolean tensor.
-            reward: Reward tensor.
-            discount: Discount factor.
-            final_reward: Last reward value in the sequence.
+            terminal: Tensor (bool) holding the is-terminal sequence. This sequence may contain more than one
+                True value. If its very last element is False (not terminating), the given `final_reward` value
+                is assumed to follow the last value in the single rewards sequence (see below).
+            reward: Tensor (float) holding the sequence of single rewards. If the last element of `terminal` is False,
+                an assumed last reward of the value of `final_reward` will be used.
+            discount (float): The discount factor (gamma). By default, take the Model's discount factor.
+            final_reward (float): Reward value to use if last episode in sequence does not terminate (terminal sequence
+                ends with False). This value will be ignored if horizon == 1 or discount == 0.0.
+            horizon (int): The length of the horizon (e.g. for n-step cumulative rewards in continuous tasks
+                without terminal signals). Use 0 (default) for an infinite horizon. Note that horizon=1 leads to the
+                exact same results as a discount factor of 0.0.
 
         Returns:
-            Discounted cumulative reward tensor.
+            Discounted cumulative reward tensor with the same shape as `reward`.
         """
 
-        # TODO: n-step cumulative reward (particularly for envs without terminal)
+        # By default -> take Model's gamma value
+        if discount is None:
+            discount = self.discount
 
-        def cumulate(cumulative, reward_and_terminal):
-            rew, term = reward_and_terminal
-            return tf.where(condition=term, x=rew, y=(rew + cumulative * discount))
+        # Accumulates discounted (n-step) reward (start new if terminal)
+        def cumulate(cumulative, reward_terminal_horizon_subtract):
+            rew, is_terminal, is_over_horizon, sub = reward_terminal_horizon_subtract
+            return tf.where(
+                # If terminal, start new cumulation.
+                condition=is_terminal,
+                x=rew,
+                y=tf.where(
+                    # If we are above the horizon length (H) -> subtract discounted value from H steps back.
+                    condition=is_over_horizon,
+                    x=(rew + cumulative * discount - sub),
+                    y=(rew + cumulative * discount)
+                )
+            )
 
-        # Reverse since reward cumulation is calculated right-to-left, but tf.scan only works left-to-right
+        # Accumulates length of episodes (starts new if terminal)
+        def len_(cumulative, term):
+            return tf.where(
+                condition=term,
+                # Start counting from 1 after is-terminal signal
+                x=tf.ones(shape=(), dtype=tf.int32),
+                # Otherwise, increase length by 1
+                y=cumulative + 1
+            )
+
+        # Reverse, since reward cumulation is calculated right-to-left, but tf.scan only works left-to-right.
         reward = tf.reverse(tensor=reward, axis=(0,))
+        # e.g. -1.0 1.0 0.5 0.0 1.0 2.0
         terminal = tf.reverse(tensor=terminal, axis=(0,))
+        # e.g. F T F F F F
 
-        reward = tf.scan(fn=cumulate, elems=(reward, terminal), initializer=tf.stop_gradient(input=final_reward))
+        # Store the steps until end of the episode(s) determined by the input terminal signals (True starts new count).
+        lengths = tf.scan(fn=len_, elems=terminal, initializer=0)
+        # e.g. 1 1 2 3 4 5
+        off_horizon = tf.greater(lengths, tf.fill(dims=tf.shape(lengths), value=horizon))
+        # e.g. F F F F T T
 
+        # Calculate the horizon-subtraction value for each step.
+        if horizon > 0:
+            horizon_subtractions = tf.map_fn(lambda x: (discount ** horizon) * x, reward, dtype=tf.float32)
+            # Shift right by size of horizon (fill rest with 0.0).
+            horizon_subtractions = tf.concat([np.zeros(shape=(horizon,)), horizon_subtractions], axis=0)
+            horizon_subtractions = tf.slice(horizon_subtractions, begin=(0,), size=tf.shape(reward))
+            # e.g. 0.0, 0.0, 0.0, -1.0*g^3, 1.0*g^3, 0.5*g^3
+        # all 0.0 if infinite horizon (special case: horizon=0)
+        else:
+            horizon_subtractions = tf.zeros(shape=tf.shape(reward))
+
+        # Now do the scan, each time summing up the previous step (discounted by gamma) and
+        # subtracting the respective `horizon_subtraction`.
+        reward = tf.scan(
+            fn=cumulate,
+            elems=(reward, terminal, off_horizon, horizon_subtractions),
+            initializer=final_reward if horizon != 1 else 0.0
+        )
+        # Re-reverse again to match input sequences.
         return tf.reverse(tensor=reward, axis=(0,))
-
-    # # TODO: this could be a utility helper function if we remove self.discount and only allow external discount-value input
-    # def tf_discounted_cumulative_reward(self, terminal, reward, discount=None, final_reward=0.0, horizon=0):
-    #     """
-    #     Creates and returns the TensorFlow operations for calculating the sequence of discounted cumulative rewards
-    #     for a given sequence of single rewards.
-
-    #     Example:
-    #     single rewards = 2.0 1.0 0.0 0.5 1.0 -1.0
-    #     terminal = False, False, False, False True False
-    #     gamma = 0.95
-    #     final_reward = 100.0 (only matters for last episode (r=-1.0) as this episode has no terminal signal)
-    #     horizon=3
-    #     output = 2.95 1.45 1.38 1.45 1.0 94.0
-
-    #     Args:
-    #         terminal: Tensor (bool) holding the is-terminal sequence. This sequence may contain more than one
-    #             True value. If its very last element is False (not terminating), the given `final_reward` value
-    #             is assumed to follow the last value in the single rewards sequence (see below).
-    #         reward: Tensor (float) holding the sequence of single rewards. If the last element of `terminal` is False,
-    #             an assumed last reward of the value of `final_reward` will be used.
-    #         discount (float): The discount factor (gamma). By default, take the Model's discount factor.
-    #         final_reward (float): Reward value to use if last episode in sequence does not terminate (terminal sequence
-    #             ends with False). This value will be ignored if horizon == 1 or discount == 0.0.
-    #         horizon (int): The length of the horizon (e.g. for n-step cumulative rewards in continuous tasks
-    #             without terminal signals). Use 0 (default) for an infinite horizon. Note that horizon=1 leads to the
-    #             exact same results as a discount factor of 0.0.
-
-    #     Returns:
-    #         Discounted cumulative reward tensor with the same shape as `reward`.
-    #     """
-
-    #     # By default -> take Model's gamma value
-    #     if discount is None:
-    #         discount = self.discount
-
-    #     # Accumulates discounted (n-step) reward (start new if terminal)
-    #     def cumulate(cumulative, reward_terminal_horizon_subtract):
-    #         rew, is_terminal, is_over_horizon, sub = reward_terminal_horizon_subtract
-    #         return tf.where(
-    #             # If terminal, start new cumulation.
-    #             condition=is_terminal,
-    #             x=rew,
-    #             y=tf.where(
-    #                 # If we are above the horizon length (H) -> subtract discounted value from H steps back.
-    #                 condition=is_over_horizon,
-    #                 x=(rew + cumulative * discount - sub),
-    #                 y=(rew + cumulative * discount)
-    #             )
-    #         )
-
-    #     # Accumulates length of episodes (starts new if terminal)
-    #     def len_(cumulative, term):
-    #         return tf.where(
-    #             condition=term,
-    #             # Start counting from 1 after is-terminal signal
-    #             x=tf.ones(shape=(), dtype=tf.int32),
-    #             # Otherwise, increase length by 1
-    #             y=cumulative + 1
-    #         )
-
-    #     # Reverse, since reward cumulation is calculated right-to-left, but tf.scan only works left-to-right.
-    #     reward = tf.reverse(tensor=reward, axis=(0,))
-    #     # e.g. -1.0 1.0 0.5 0.0 1.0 2.0
-    #     terminal = tf.reverse(tensor=terminal, axis=(0,))
-    #     # e.g. F T F F F F
-
-    #     # Store the steps until end of the episode(s) determined by the input terminal signals (True starts new count).
-    #     lengths = tf.scan(fn=len_, elems=terminal, initializer=0)
-    #     # e.g. 1 1 2 3 4 5
-    #     off_horizon = tf.greater(lengths, tf.fill(dims=tf.shape(lengths), value=horizon))
-    #     # e.g. F F F F T T
-
-    #     # Calculate the horizon-subtraction value for each step.
-    #     if horizon > 0:
-    #         horizon_subtractions = tf.map_fn(lambda x: (discount ** horizon) * x, reward, dtype=tf.float32)
-    #         # Shift right by size of horizon (fill rest with 0.0).
-    #         horizon_subtractions = tf.concat([np.zeros(shape=(horizon,)), horizon_subtractions], axis=0)
-    #         horizon_subtractions = tf.slice(horizon_subtractions, begin=(0,), size=tf.shape(reward))
-    #         # e.g. 0.0, 0.0, 0.0, -1.0*g^3, 1.0*g^3, 0.5*g^3
-    #     # all 0.0 if infinite horizon (special case: horizon=0)
-    #     else:
-    #         horizon_subtractions = tf.zeros(shape=tf.shape(reward))
-
-    #     # Now do the scan, each time summing up the previous step (discounted by gamma) and
-    #     # subtracting the respective `horizon_subtraction`.
-    #     reward = tf.scan(
-    #         fn=cumulate,
-    #         elems=(reward, terminal, off_horizon, horizon_subtractions),
-    #         initializer=final_reward if horizon != 1 else 0.0
-    #     )
-    #     # Re-reverse again to match input sequences.
-    #     return tf.reverse(tensor=reward, axis=(0,))
 
     def tf_reference(self, states, internals, actions, terminal, reward, next_states, next_internals, update):
         """
@@ -316,13 +336,14 @@ class MemoryModel(Model):
         """
         return None
 
-    def tf_loss_per_instance(self, states, internals, actions, terminal, reward, next_states, next_internals, update, reference=None):
+    def tf_loss_per_instance(self, states, internals, actions, terminal, reward,
+                             next_states, next_internals, update, reference=None):
         """
         Creates the TensorFlow operations for calculating the loss per batch instance.
 
         Args:
             states: Dict of state tensors.
-            internals: List of prior internal state tensors.
+            internals: Dict of prior internal state tensors.
             actions: Dict of action tensors.
             terminal: Terminal boolean tensor.
             reward: Reward tensor.
@@ -413,16 +434,16 @@ class MemoryModel(Model):
         and various functions which the optimizer might require to perform an update step.
 
         Args:
-            states: Dict of state tensors.
-            internals: List of prior internal state tensors.
-            actions: Dict of action tensors.
-            terminal: Terminal boolean tensor.
-            reward: Reward tensor.
-            next_states: Dict of successor state tensors.
-            next_internals: List of posterior internal state tensors.
+            states (dict): Dict of state tensors.
+            internals (dict): Dict of prior internal state tensors.
+            actions (dict): Dict of action tensors.
+            terminal: 1D boolean is-terminal tensor.
+            reward: 1D (float) rewards tensor.
+            next_states (dict): Dict of successor state tensors.
+            next_internals (dict): Dict of posterior internal state tensors.
 
         Returns:
-            Optimizer arguments as dict.
+            Optimizer arguments as dict to be used as **kwargs to the optimizer.
         """
         arguments = dict(
             time=self.global_timestep,
@@ -474,16 +495,8 @@ class MemoryModel(Model):
 
     def tf_observe_timestep(self, states, internals, actions, terminal, reward):
         """
-
-        Args:
-            states ():
-            internals ():
-            actions ():
-            terminal ():
-            reward ():
-
-        Returns:
-
+        Creates and returns the op that - if frequency condition is hit - pulls a batch from the memory
+        and does one optimization step.
         """
         # Store timestep in memory
         stored = self.memory.store(

--- a/tensorforce/models/pg_model.py
+++ b/tensorforce/models/pg_model.py
@@ -73,6 +73,7 @@ class PGModel(DistributionModel):
         self.baseline = None
         self.baseline_optimizer = None
         self.fn_reward_estimation = None
+        self.fn_baseline_loss = None
 
         super(PGModel, self).__init__(
             states=states,
@@ -105,8 +106,8 @@ class PGModel(DistributionModel):
                 optimizer=self.baseline_optimizer_spec
             )
 
-    def initialize(self, custom_getter):
-        super(PGModel, self).initialize(custom_getter)
+    def setup_components_and_tf_funcs(self, custom_getter=None):
+        custom_getter = super(PGModel, self).setup_components_and_tf_funcs(custom_getter)
 
         # Baseline
         if self.baseline_spec is None:
@@ -145,6 +146,8 @@ class PGModel(DistributionModel):
             func_=self.tf_baseline_loss,
             custom_getter_=custom_getter
         )
+
+        return custom_getter
 
     def tf_reward_estimation(self, states, internals, terminal, reward, update):
         if self.baseline_mode is None:

--- a/tensorforce/models/q_demo_model.py
+++ b/tensorforce/models/q_demo_model.py
@@ -68,6 +68,12 @@ class QDemoModel(QModel):
         self.demo_memory_capacity = demo_memory_capacity
         self.demo_batch_size = demo_batch_size
 
+        self.demo_memory = None
+        self.fn_import_demo_experience = None
+        self.fn_demo_loss = None
+        self.fn_combined_loss = None
+        self.fn_demo_optimization = None
+
         super(QDemoModel, self).__init__(
             states=states,
             actions=actions,
@@ -94,8 +100,11 @@ class QDemoModel(QModel):
             huber_loss=huber_loss
         )
 
-    def initialize(self, custom_getter):
-        super(QDemoModel, self).initialize(custom_getter=custom_getter)
+    def setup_components_and_tf_funcs(self, custom_getter=None):
+        """
+        Constructs the extra Replay memory.
+        """
+        custom_getter = super(QDemoModel, self).setup_components_and_tf_funcs(custom_getter)
 
         self.demo_memory = Replay(
             states=self.states_spec,
@@ -134,6 +143,8 @@ class QDemoModel(QModel):
             func_=self.tf_demo_optimization,
             custom_getter_=custom_getter
         )
+
+        return custom_getter
 
     def tf_initialize(self):
         super(QDemoModel, self).tf_initialize()

--- a/tensorforce/models/q_model.py
+++ b/tensorforce/models/q_model.py
@@ -105,8 +105,8 @@ class QModel(DistributionModel):
             optimizer=self.target_optimizer_spec
         )
 
-    def initialize(self, custom_getter):
-        super(QModel, self).initialize(custom_getter)
+    def setup_components_and_tf_funcs(self, custom_getter=None):
+        super(QModel, self).setup_components_and_tf_funcs(custom_getter)
 
         # # TEMP: Random sampling fix
         # if self.random_sampling_fix:

--- a/tensorforce/models/q_naf_model.py
+++ b/tensorforce/models/q_naf_model.py
@@ -83,8 +83,8 @@ class QNAFModel(QModel):
             huber_loss=huber_loss
         )
 
-    def initialize(self, custom_getter):
-        super(QNAFModel, self).initialize(custom_getter)
+    def setup_components_and_tf_funcs(self, custom_getter=None):
+        super(QNAFModel, self).setup_components_and_tf_funcs(custom_getter)
 
         self.state_values = dict()
         self.l_entries = dict()

--- a/tensorforce/tests/base_agent_test.py
+++ b/tensorforce/tests/base_agent_test.py
@@ -19,7 +19,7 @@ from __future__ import division
 
 from tensorforce.tests.base_test import BaseTest
 from tensorforce.core.networks import Dense, LayerBasedNetwork
-from tensorforce.environments import MinimalTest
+from tensorforce.tests.minimal_test import MinimalTest
 
 
 class BaseAgentTest(BaseTest):

--- a/tensorforce/tests/test_model_save_restore.py
+++ b/tensorforce/tests/test_model_save_restore.py
@@ -8,7 +8,7 @@ import pytest
 from tensorforce import TensorForceError
 from tensorforce.core.networks import LayeredNetwork
 from tensorforce.models import DistributionModel
-from tensorforce.tests.minimal_test import MinimalTest
+from .minimal_test import MinimalTest
 from tensorforce.agents import PPOAgent
 from tensorforce.execution import Runner
 import tensorflow as tf

--- a/tensorforce/tests/test_tutorial_code.py
+++ b/tensorforce/tests/test_tutorial_code.py
@@ -420,7 +420,7 @@ class TestTutorialCode(unittest.TestCase):
         agent.close()
 
     def test_blogpost_introduction_runner(self):
-        from tensorforce.tests.minimal_test import MinimalTest
+        from .minimal_test import MinimalTest
         from tensorforce.agents import DQNAgent
         from tensorforce.execution import Runner
 

--- a/tensorforce/tests/test_vpg_baselines.py
+++ b/tensorforce/tests/test_vpg_baselines.py
@@ -22,7 +22,7 @@ import unittest
 from tensorforce.tests.base_test import BaseTest
 from tensorforce.agents import VPGAgent
 from tensorforce.core.networks import Dense, LayerBasedNetwork
-from tensorforce.environments import MinimalTest
+from .minimal_test import MinimalTest
 
 
 class TestVPGBaselines(BaseTest, unittest.TestCase):

--- a/tensorforce/tests/test_vpg_memories.py
+++ b/tensorforce/tests/test_vpg_memories.py
@@ -21,7 +21,7 @@ import unittest
 
 from tensorforce.tests.base_test import BaseTest
 from tensorforce.agents import VPGAgent
-from tensorforce.environments import MinimalTest
+from .minimal_test import MinimalTest
 
 
 class TestVPGMemories(BaseTest, unittest.TestCase):

--- a/tensorforce/tests/test_vpg_multithreaded.py
+++ b/tensorforce/tests/test_vpg_multithreaded.py
@@ -23,7 +23,7 @@ import sys
 import unittest
 
 from tensorforce.agents import VPGAgent
-from tensorforce.environments import MinimalTest
+from .minimal_test import MinimalTest
 from tensorforce.execution import ThreadedRunner
 from tensorforce.execution.threaded_runner import clone_worker_agent
 

--- a/tensorforce/tests/test_vpg_optimizers.py
+++ b/tensorforce/tests/test_vpg_optimizers.py
@@ -21,7 +21,7 @@ import unittest
 
 from tensorforce.tests.base_test import BaseTest
 from tensorforce.agents import VPGAgent
-from tensorforce.environments import MinimalTest
+from .minimal_test import MinimalTest
 
 
 class TestVPGOptimizers(BaseTest, unittest.TestCase):


### PR DESCRIPTION
Major refactor in model.py.initialize: Split, renamed and further packaging of sub-tasks by the model's setup function. This will make it easier to write sub-classes for `Model`. Added some missing doc-strings. 
Moved global counters into a cleaner tf.get_variable-logic (instead tf.Variable).

Slight Memory-classes refactor. Moved tf function creation into its own setup function called by init.

Optimizers: Some commenting, removed get_wrapper (replaced by functools.partial).