### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ agent.observe(reward=reward, terminal=False)
 Benchmarks
 ----------
 
-We provide a seperate repository for benchmarking our algorithm implementations at
+We provide a separate repository for benchmarking our algorithm implementations at
 [reinforceio/tensorforce-benchmark](https://github.com/reinforceio/tensorforce-benchmark).
 
 Docker containers for benchmarking (CPU and GPU) are available.


### PR DESCRIPTION
'seperate' -> 'separate'