### PR TITLE
Finish API changes to remove _spec

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,9 +40,9 @@ In python, it could look like this:
    ]
 
    agent = PPOAgent(
-       states_spec=env.states,
-       actions_spec=env.actions,
-       network_spec=network_spec,
+       states=env.states,
+       actions=env.actions,
+       network=network_spec,
        batch_size=4096,
        # BatchAgent
        keep_last_timestep=True,

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -85,9 +85,9 @@ def main():
     ]
 
     agent = DQNAgent(
-        states_spec=env.states,
-        actions_spec=env.actions,
-        network_spec=network_spec,
+        states=env.states,
+        actions=env.actions,
+        network=network_spec,
         batch_size=64
     )
 

--- a/examples/ale.py
+++ b/examples/ale.py
@@ -81,9 +81,9 @@ def main():
     agent = Agent.from_spec(
         spec=agent_config,
         kwargs=dict(
-            states_spec=environment.states,
-            actions_spec=environment.actions,
-            network_spec=network_spec
+            states=environment.states,
+            actions=environment.actions,
+            network=network_spec
         )
     )
 

--- a/examples/lab_main.py
+++ b/examples/lab_main.py
@@ -83,9 +83,9 @@ def main():
     agent = Agent.from_spec(
         spec=agent_config,
         kwargs=dict(
-            states_spec=environment.states,
-            actions_spec=environment.actions,
-            network_spec=network_spec
+            states=environment.states,
+            actions=environment.actions,
+            network=network_spec
         )
     )
     if args.load:

--- a/examples/openai_universe.py
+++ b/examples/openai_universe.py
@@ -81,9 +81,9 @@ def main():
     agent = Agent.from_spec(
         spec=agent_config,
         kwargs=dict(
-            states_spec=environment.states,
-            actions_spec=environment.actions,
-            network_spec=network_spec
+            states=environment.states,
+            actions=environment.actions,
+            network=network_spec
         )
     )
 

--- a/examples/threaded_ale.py
+++ b/examples/threaded_ale.py
@@ -114,9 +114,9 @@ def main():
     agent = Agent.from_spec(
         spec=agent_configs[0],
         kwargs=dict(
-            states_spec=environments[0].states,
-            actions_spec=environments[0].actions,
-            network_spec=network_spec
+            states=environments[0].states,
+            actions=environments[0].actions,
+            network=network_spec
         )
     )
 
@@ -126,9 +126,9 @@ def main():
         config = agent_configs[i]
         agent_type = config.pop('type', None)
         worker = WorkerAgentGenerator(AgentsDictionary[agent_type])(
-            states_spec=environments[0].states,
-            actions_spec=environments[0].actions,
-            network_spec=network_spec,
+            states=environments[0].states,
+            actions=environments[0].actions,
+            network=network_spec,
             model=agent.model,
             **config
         )

--- a/tensorforce/models/model.py
+++ b/tensorforce/models/model.py
@@ -49,7 +49,7 @@ class Model(object):
 
     * `tf_preprocess(states, internals, reward)` for states/action/reward preprocessing (e.g. reward normalization),
         returning the pre-processed tensors.
-    * `tf_action_exploration(action, exploration, action_spec)` for action postprocessing (e.g. exploration),
+    * `tf_action_exploration(action, exploration, actions)` for action postprocessing (e.g. exploration),
         returning the processed batch of actions.
     * `create_output_operations(states, internals, actions, terminal, reward, deterministic)` for further output operations,
         similar to the two above for `Model.act` and `Model.update`.
@@ -98,7 +98,7 @@ class Model(object):
             tf_session_dump_dir (str): If non-empty string, all session.run calls will be dumped using the tensorflow
                 offline-debug session into the given directory.
         """
-        # Network crated from network_spec in distribution_model.py
+        # Network crated from network in distribution_model.py
         # Needed for named_tensor access
         self.network = None
 

--- a/tensorforce/tests/test_reward_estimation.py
+++ b/tensorforce/tests/test_reward_estimation.py
@@ -40,9 +40,9 @@ class TestRewardEstimation(unittest.TestCase):
             learning_rate=0.001,
         )
         # agent = VPGAgent(
-        #     states_spec=dict(shape=(1,)),
-        #     actions_spec=dict(type='int', num_actions=2),
-        #     network_spec=[dict(type='dense', size=32)],
+        #     states=dict(shape=(1,)),
+        #     actions=dict(type='int', num_actions=2),
+        #     network=[dict(type='dense', size=32)],
         #     config=config
         # )
 
@@ -72,9 +72,9 @@ class TestRewardEstimation(unittest.TestCase):
             learning_rate=0.001,
         )
         # agent = VPGAgent(
-        #     states_spec=dict(shape=(1,)),
-        #     actions_spec=dict(type='int', num_actions=2),
-        #     network_spec=[dict(type='dense', size=32)],
+        #     states=dict(shape=(1,)),
+        #     actions=dict(type='int', num_actions=2),
+        #     network=[dict(type='dense', size=32)],
         #     config=config
         # )
 
@@ -104,9 +104,9 @@ class TestRewardEstimation(unittest.TestCase):
             # gae_lambda=0.5
         )
         # agent = VPGAgent(
-        #     states_spec=dict(shape=(1,)),
-        #     actions_spec=dict(type='int', num_actions=2),
-        #     network_spec=[dict(type='dense', size=32)],
+        #     states=dict(shape=(1,)),
+        #     actions=dict(type='int', num_actions=2),
+        #     network=[dict(type='dense', size=32)],
         #     config=config
         # )
 


### PR DESCRIPTION
Commit reinforceio/tensorforce@ec7c970 modified some
agent/model arguments.

This commit fixes some uses of the API that were still using the
old argument names

Changed:
  states_spec to states
  actions_spec to actions
  network_spec to network