### PR TITLE
Initialize terminal memory to match tensorflow's expected type

### DIFF
--- a/tensorforce/core/memories/queue.py
+++ b/tensorforce/core/memories/queue.py
@@ -102,7 +102,7 @@ class Queue(Memory):
             shape=(self.capacity,),
             dtype=util.tf_dtype('bool'),
             initializer=tf.constant_initializer(
-                value=tuple(n == self.capacity - 1 for n in range(self.capacity)),
+                value=[n == self.capacity - 1 for n in range(self.capacity)],
                 dtype=util.tf_dtype('bool')
             ),
             trainable=False

--- a/tensorforce/core/memories/queue.py
+++ b/tensorforce/core/memories/queue.py
@@ -102,7 +102,7 @@ class Queue(Memory):
             shape=(self.capacity,),
             dtype=util.tf_dtype('bool'),
             initializer=tf.constant_initializer(
-                value=[n == self.capacity - 1 for n in range(self.capacity)],
+                value=tuple(bool(n == self.capacity - 1) for n in range(self.capacity)),
                 dtype=util.tf_dtype('bool')
             ),
             trainable=False


### PR DESCRIPTION
Fix for #388.  When queue.capacity is an np.int64, the comparison leads to an np.bool_ type, rather than a python bool, which is what's necessary for the initializer, which is a tf.bool.