### PR TITLE
Implement testing flag to runner to evaluate agent with runner.

### DIFF
--- a/examples/openai_gym.py
+++ b/examples/openai_gym.py
@@ -56,6 +56,7 @@ def main():
     parser.add_argument('--monitor-video', type=int, default=0, help="Save video every x steps (0 = disabled)")
     parser.add_argument('--visualize', action='store_true', default=False, help="Enable OpenAI Gym's visualization")
     parser.add_argument('-D', '--debug', action='store_true', default=False, help="Show debug outputs")
+    parser.add_argument('-te', '--test', action='store_true', default=False, help="Test agent without learning.")
     parser.add_argument('--job', type=str, default=None, help="For distributed mode: The job type of this agent.")
     parser.add_argument('--task', type=int, default=0, help="For distributed mode: The task index of this agent.")
 
@@ -163,7 +164,8 @@ def main():
         num_episodes=args.episodes,
         max_episode_timesteps=args.max_episode_timesteps,
         deterministic=args.deterministic,
-        episode_finished=episode_finished
+        episode_finished=episode_finished,
+        testing=args.test
     )
     runner.close()
 

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -48,7 +48,7 @@ class Runner(BaseRunner):
 
     # TODO: make average reward another possible criteria for runner-termination
     def run(self, num_timesteps=None, num_episodes=None, max_episode_timesteps=None, deterministic=False,
-            episode_finished=None, summary_report=None, summary_interval=None, timesteps=None, episodes=None
+            episode_finished=None, summary_report=None, summary_interval=None, timesteps=None, episodes=None, testing=False,
             ):
         """
         Args:
@@ -109,7 +109,8 @@ class Runner(BaseRunner):
                 if max_episode_timesteps is not None and self.current_timestep >= max_episode_timesteps:
                     terminal = True
 
-                self.agent.observe(terminal=terminal, reward=reward)
+                if not testing:
+                    self.agent.observe(terminal=terminal, reward=reward)
 
                 self.global_timestep += 1
                 self.current_timestep += 1


### PR DESCRIPTION
A simple implementation to allow the runner to test an agent on an environment without learning. Loading weights from file and running the agent on an environment is then simply like the enjoy_scripts in openai/baselines.

P.S. Thanks for this library, is is absolutely amazingly clean and well designed. I would love to contribute to this in the future.

I implemented the test flag in openai_gym.py for now, but it can easily be added to all other examples as soon as you guys are happy with my idea.