### PR TITLE
Implement sleep parameter to runner to allow slowing down execution

### DIFF
--- a/examples/openai_gym.py
+++ b/examples/openai_gym.py
@@ -57,6 +57,7 @@ def main():
     parser.add_argument('--visualize', action='store_true', default=False, help="Enable OpenAI Gym's visualization")
     parser.add_argument('-D', '--debug', action='store_true', default=False, help="Show debug outputs")
     parser.add_argument('-te', '--test', action='store_true', default=False, help="Test agent without learning.")
+    parser.add_argument('-sl', '--sleep', type=float, default=None, help="Slow down simulation by sleeping for x seconds (fractions allowed).")
     parser.add_argument('--job', type=str, default=None, help="For distributed mode: The job type of this agent.")
     parser.add_argument('--task', type=int, default=0, help="For distributed mode: The task index of this agent.")
 
@@ -165,7 +166,8 @@ def main():
         max_episode_timesteps=args.max_episode_timesteps,
         deterministic=args.deterministic,
         episode_finished=episode_finished,
-        testing=args.test
+        testing=args.test,
+        sleep=args.sleep
     )
     runner.close()
 

--- a/tensorforce/execution/runner.py
+++ b/tensorforce/execution/runner.py
@@ -48,7 +48,7 @@ class Runner(BaseRunner):
 
     # TODO: make average reward another possible criteria for runner-termination
     def run(self, num_timesteps=None, num_episodes=None, max_episode_timesteps=None, deterministic=False,
-            episode_finished=None, summary_report=None, summary_interval=None, timesteps=None, episodes=None, testing=False,
+            episode_finished=None, summary_report=None, summary_interval=None, timesteps=None, episodes=None, testing=False, sleep=None
             ):
         """
         Args:
@@ -118,6 +118,9 @@ class Runner(BaseRunner):
 
                 if terminal or self.agent.should_stop():  # TODO: should_stop also terminate?
                     break
+
+                if sleep is not None:
+                    time.sleep(sleep)
 
             # Update our episode stats.
             time_passed = time.time() - episode_start_time

--- a/tensorforce/execution/threaded_runner.py
+++ b/tensorforce/execution/threaded_runner.py
@@ -96,7 +96,8 @@ class ThreadedRunner(BaseRunner):
         deterministic=False,
         episodes=None,
         max_timesteps=None,
-        testing=False
+        testing=False,
+        sleep=None
     ):
         """
         Executes this runner by starting all Agents in parallel (each one in one thread).
@@ -136,7 +137,8 @@ class ThreadedRunner(BaseRunner):
                                     kwargs={"deterministic": deterministic,
                                             "max_episode_timesteps": max_episode_timesteps,
                                             "episode_finished": episode_finished,
-                                            "testing": testing})
+                                            "testing": testing,
+                                            "sleep": sleep})
                    for t in range(len(self.agent))]
 
         # Start threads.
@@ -184,7 +186,7 @@ class ThreadedRunner(BaseRunner):
         print('All threads stopped')
 
     def _run_single(self, thread_id, agent, environment, deterministic=False,
-                    max_episode_timesteps=-1, episode_finished=None, testing=False):
+                    max_episode_timesteps=-1, episode_finished=None, testing=False, sleep=None):
         """
         The target function for a thread, runs an agent and environment until signaled to stop.
         Adds rewards to shared episode rewards list.
@@ -234,6 +236,10 @@ class ThreadedRunner(BaseRunner):
                         reward=reward,
                         terminal=terminal
                     )
+
+                if sleep is not None:
+                    time.sleep(sleep)
+
                 time_step += 1
                 episode_reward += reward
 


### PR DESCRIPTION
This is especially useful when analyzing the visualization of performance. Running it at normal speed is usually too fast to see what is going on. Like this, it is possible to set --sleep x (seconds, e.g. 0.05 ) in order to make the runner sleep before continuing.

If you do not like the scaling of the sleep representation of time (x vs. 1/x), we can change that to something more useful. I just thought it might make sense to allow the user to choose arbitrary numbers (never restrict too much if you do not know what people are doing with it). We can discuss this here if necessary.