### PR TITLE
Action clarified 

### DIFF
--- a/tensorforce/contrib/ale.py
+++ b/tensorforce/contrib/ale.py
@@ -93,12 +93,12 @@ class ALE(Environment):
         self.gamescreen = np.empty(self.gamescreen.shape, dtype=np.uint8)
         return self.current_state
 
-    def execute(self, actions):
+    def execute(self, action):
         # Convert action to ale action.
-        ale_actions = self.action_inds[actions]
+        ale_action = self.action_inds[action]
 
         # Get reward and process terminal & next state.
-        rew = self.ale.act(ale_actions)
+        rew = self.ale.act(ale_action)
         if self.loss_of_life_termination or self.loss_of_life_reward != 0:
             new_lives = self.ale.lives()
             if new_lives < self.cur_lives:

--- a/tensorforce/contrib/deepmind_lab.py
+++ b/tensorforce/contrib/deepmind_lab.py
@@ -109,7 +109,7 @@ class DeepMindLab(Environment):
         self.level.reset()  # optional: episode=-1, seed=None
         return self.level.observations()[self.state_attribute]
 
-    def execute(self, actions):
+    def execute(self, action):
         """
         Pass action to universe environment, return reward, next step, terminal state and
         additional info.
@@ -119,15 +119,15 @@ class DeepMindLab(Environment):
         :return: dict containing the next state, the reward, and a boolean indicating if the
             next state is a terminal state
         """
-        adjusted_actions = list()
+        adjusted_action = list()
         for action_spec in self.level.action_spec():
             if action_spec['min'] == -1 and action_spec['max'] == 1:
-                adjusted_actions.append(actions[action_spec['name']] - 1)
+                adjusted_action.append(action[action_spec['name']] - 1)
             else:
-                adjusted_actions.append(actions[action_spec['name']])  # clip?
-        actions = np.array(adjusted_actions, dtype=np.intc)
+                adjusted_action.append(action[action_spec['name']])  # clip?
+        action = np.array(adjusted_action, dtype=np.intc)
 
-        reward = self.level.step(action=actions, num_steps=self.repeat_action)
+        reward = self.level.step(action=action, num_steps=self.repeat_action)
         state = self.level.observations()['RGB_INTERLACED']
         terminal = not self.level.is_running()
         return state, terminal, reward

--- a/tensorforce/contrib/game_2048.py
+++ b/tensorforce/contrib/game_2048.py
@@ -35,7 +35,7 @@ class Game2048(Environment):
         self.__init__()
         return self._state
 
-    def execute(self, actions):
+    def execute(self, action):
         reward = 0
 
         # Terminal
@@ -44,11 +44,11 @@ class Game2048(Environment):
             return self._state, terminal, reward
 
         # Valid action
-        action_available = self.is_action_available(actions)
+        action_available = self.is_action_available(action)
         if not action_available:
             return self._state, terminal, reward
 
-        reward = self.do_action(actions)
+        reward = self.do_action(action)
 
         return self._state, terminal, reward
 

--- a/tensorforce/contrib/openai_gym.py
+++ b/tensorforce/contrib/openai_gym.py
@@ -65,13 +65,10 @@ class OpenAIGym(Environment):
             self.gym.stats_recorder.done = True
         return self.gym.reset()
 
-    def execute(self, actions):
+    def execute(self, action):
         if self.visualize:
             self.gym.render()
-        # if the actions is not unique, that is, if the actions is a dict
-        if isinstance(actions, dict):
-            actions = [actions['action{}'.format(n)] for n in range(len(actions))]
-        state, reward, terminal, _ = self.gym.step(actions)
+        state, reward, terminal, _ = self.gym.step(action)
         return state, terminal, reward
 
     @property

--- a/tensorforce/contrib/pygame_learning_environment.py
+++ b/tensorforce/contrib/pygame_learning_environment.py
@@ -19,7 +19,6 @@ from __future__ import division
 
 import time
 
-import tensorforce
 from tensorforce import TensorForceError
 from tensorforce.environments.environment import Environment
 
@@ -94,7 +93,7 @@ class PLE(Environment):
         self.env.reset_game()
         return self.env.getScreenRGB()
 
-    def execute(self, actions):
+    def execute(self, action):
         """
         Executes action, observes next state and reward.
 
@@ -107,9 +106,8 @@ class PLE(Environment):
         if self.env.game_over():
             return self.env.getScreenRGB(), True, 0
 
-        # TODO clarification of actions allowing multiple actions
         action_space = self.env.getActionSet()
-        reward = self.env.act(action_space[actions])
+        reward = self.env.act(action_space[action])
         new_state = self.env.getScreenRGB()
         done = self.env.game_over()
         return new_state, done, reward
@@ -140,4 +138,3 @@ class PLE(Environment):
             'shape' : (len(self.env.getActionSet()),),
             'type' : int
         }
-

--- a/tensorforce/contrib/unreal_engine.py
+++ b/tensorforce/contrib/unreal_engine.py
@@ -152,7 +152,7 @@ class UE4Environment(RemoteEnvironment, StateSettableEnvironment):
         response = self.protocol.recv(self.socket)
         return self.extract_observation(response)
 
-    def execute(self, actions):
+    def execute(self, action):
         """
         Executes a single step in the UE4 game. This step may be comprised of one or more actual game ticks for all of
         which the same given
@@ -168,7 +168,7 @@ class UE4Environment(RemoteEnvironment, StateSettableEnvironment):
         # Discretized -> each action is an int
         if self.discretize_actions:
             # Pull record from discretized_actions, which will look like: [A, Right, SpaceBar].
-            combination = self.discretized_actions[actions]
+            combination = self.discretized_actions[action]
             # Translate to {"axis_mappings": [('A', 1.0), (Right, 1.0)], "action_mappings": [(SpaceBar, True)]}
             for key, value in combination:
                 # Action mapping (True or False).
@@ -179,9 +179,9 @@ class UE4Environment(RemoteEnvironment, StateSettableEnvironment):
                     axis_mappings.append((key, value))
         # Non-discretized: Each action is a dict of action- and axis-mappings defined in UE4 game's input settings.
         # Re-translate Incoming action names into keyboard keys for the server.
-        elif actions:
+        elif action:
             try:
-                action_mappings, axis_mappings = self.translate_abstract_actions_to_keys(actions)
+                action_mappings, axis_mappings = self.translate_abstract_actions_to_keys(action)
             except KeyError as e:
                 raise TensorForceError("Action- or axis-mapping with name '{}' not defined in connected UE4 game!".
                                        format(e))

--- a/tensorforce/environments/environment.py
+++ b/tensorforce/environments/environment.py
@@ -56,7 +56,7 @@ class Environment(object):
         """
         raise NotImplementedError
 
-    def execute(self, actions):
+    def execute(self, action):
         """
         Executes action, observes next state(s) and reward.
 
@@ -64,7 +64,7 @@ class Environment(object):
             actions: Actions to execute.
 
         Returns:
-            (Dict of) next state(s), boolean indicating terminal, and reward signal.
+            Tuple of (next state, bool indicating terminal, reward)
         """
         raise NotImplementedError
 


### PR DESCRIPTION
in #438 I raised the issue of actions not making sense (passing multiple actions to a step) and noted that many user implemented environments (in particular ale, 2048, and unreal engine) didn't actually implement this action. Furthermore, the requirement for a dictionary return also didn't make sense, so I decided to change this. 

In order to normalize things (to make sense with what we think of when we choose actions in the Markov Decision Process), I've deleted this functionality and changed the documentation to make more sense and be more consistent. 

Most environments have remained unchanged. However, for openai_gym, the implementation has been changed. Importantly, as it was implemented, passing in lists was impossible (as you can't pass in a list of actions for env.step) so this functionality was defunct anyways. 

I still have yet to implement this for open_ai universe, as I haven't been able to install this even on python 2.7. I will change this ASAP, but this input still doesn't make sense. 